### PR TITLE
Show "Currently going: x/y" in event page

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ A simple minimal web application for managing events and RSVPs. Users can create
 
 - **Frontend:** SvelteKit, TypeScript, Tailwind CSS
 - **Backend:** Node.js, Express, TypeScript
-- **Database:** PostgreSQL
+- **Database:** SQLite
 - **Other:** Vite, ESLint, Prettier
 
 ---
@@ -17,7 +17,6 @@ A simple minimal web application for managing events and RSVPs. Users can create
 
 - Node.js
 - yarn
-- PostgreSQL (running locally or accessible remotely)
 
 ---
 

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -13,7 +13,7 @@
 
   let attendees = data.rsvp
   let isRsvpFull = attendees.filter(a => a.status === 'going').reduce((sum, a) => sum + 1 + (a.guests || 0), 0) >= event.max_attendees
-  $: goingCount = attendees.filter(a => a.status === 'going').length;
+  $: goingCount = attendees.filter(a => a.status === 'going').reduce((total, attendee) => total + 1 + (attendee.guests ?? 0), 0);
 
   interface RSVPRequestBody {
     name: string;

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -13,6 +13,7 @@
 
   let attendees = data.rsvp
   let isRsvpFull = attendees.filter(a => a.status === 'going').reduce((sum, a) => sum + 1 + (a.guests || 0), 0) >= event.max_attendees
+  $: goingCount = attendees.filter(a => a.status === 'going').length;
 
   interface RSVPRequestBody {
     name: string;
@@ -120,7 +121,7 @@
     <div class="mb-2"><span class="font-semibold">Time:</span> {formattedTime}</div>
     <div class="mb-2"><span class="font-semibold">Location:</span> {event.location}</div>
     {#if event.max_attendees}
-      <div class="mb-2"><span class="font-semibold">Max Attendees:</span> {event.max_attendees}</div>
+      <div class="mb-2"><span class="font-semibold">Currently going:</span> {goingCount}/{event.max_attendees}</div>
     {/if}
 
 


### PR DESCRIPTION
This way is just easier to quickly see how full the event is without pulling down the "show responses" thing.

Also, LLMs are incredible. I have no idea what I'm doing so any suggestions lemme know!