### PR TITLE
Require end time when creating events, fix calendar button for events without end time

### DIFF
--- a/client/src/routes/create-event/+page.svelte
+++ b/client/src/routes/create-event/+page.svelte
@@ -32,10 +32,14 @@
   async function handleSubmit(event: Event) {
     event.preventDefault();
     // Validate required fields
-    if (!name.trim() || !date.trim() || !location.trim() || !startTime.trim()) {
+    if (!name.trim() || !date.trim() || !location.trim() || !startTime.trim() || !endTime.trim()) {
       alert(
-        "Please fill in all required fields: Name, Date, Starting Time, and Location.",
+        "Please fill in all required fields: Name, Date, Starting Time, Ending Time, and Location.",
       );
+      return;
+    }
+    if (endTime <= startTime) {
+      alert("Ending time must be after starting time.");
       return;
     }
     loading = true;
@@ -141,24 +145,31 @@
       </div>
       <div>
         <label for="startTime" class="mb-1 block font-semibold"
-          >Starting Time</label
+          >Starting Time<span class="ml-1 text-red-500" aria-hidden="true">*</span
+	  ></label
         >
         <input
           id="startTime"
           name="startTime"
           type="time"
           bind:value={startTime}
+          required
+          aria-required="true"
           class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
         />
       </div>
       <div>
-        <label for="endTime" class="mb-1 block font-semibold">Ending Time</label
+        <label for="endTime" class="mb-1 block font-semibold"
+          >Ending Time<span class="ml-1 text-red-500" aria-hidden="true">*</span
+	  ></label
         >
         <input
           id="endTime"
           name="endTime"
           type="time"
           bind:value={endTime}
+          required
+          aria-required="true"
           class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
         />
       </div>

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -171,7 +171,7 @@
           name={event.name}
           startDate={event.date}
           startTime={event.start_time}
-          endTime={event.end_time ?? (event.start_time ? addOneHour(event.start_time) : undefined)}
+          endTime={event.end_time ?? addOneHour(event.start_time)}
           timeZone="Europe/Berlin"
           location={event.location}
           options="['Google', 'Apple', 'iCal', 'Microsoft365', 'MicrosoftTeams', 'Outlook.com', 'Yahoo']"

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -18,6 +18,11 @@
   import MapLink from '$lib/MapLink.svelte';
   import { isUserOnWaitlist } from '../../../utils/isUserOnWaitlist';
 
+  function addOneHour(time: string): string {
+    const [h, m] = time.split(':').map(Number);
+    return `${String((h + 1) % 24).padStart(2, '0')}:${String(m).padStart(2, '0')}`;
+  }
+
   type RSVPRequestBody = {
     name: string;
     status: typeof rsvp;
@@ -166,7 +171,7 @@
           name={event.name}
           startDate={event.date}
           startTime={event.start_time}
-          endTime={event.end_time}
+          endTime={event.end_time ?? (event.start_time ? addOneHour(event.start_time) : undefined)}
           timeZone="Europe/Berlin"
           location={event.location}
           options="['Google', 'Apple', 'iCal', 'Microsoft365', 'MicrosoftTeams', 'Outlook.com', 'Yahoo']"

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -4,8 +4,11 @@ import { getRsvpByEventId } from '../services/rsvp';
 
 export const createEvent = async (req: Request, res: Response, next: Function) => {
   const { name, date, startTime, endTime, maxAttendees, location } = req.body;
-  if (!name || !date || !location || !startTime) {
-    return res.status(400).json({ error: "Name, date, startTime, and location are required." });
+  if (!name || !date || !location || !startTime || !endTime) {
+    return res.status(400).json({ error: "Name, date, startTime, endTime, and location are required." });
+  }
+  if (endTime <= startTime) {
+    return res.status(400).json({ error: "endTime must be after startTime." });
   }
   try {
     const event = await createEventService({ name, date, startTime, endTime, maxAttendees, location });


### PR DESCRIPTION
- End time is now mandatory alongside start time in the create event form
- Check that end time is after start time
- Calendar button now shows for existing events missing end time by falling back to 1 hour after start