### PR TITLE
Timed registration with admin early access

### DIFF
--- a/client/src/lib/RSVPForm.svelte
+++ b/client/src/lib/RSVPForm.svelte
@@ -5,6 +5,7 @@
   export let attendeeName: string;
   export let onSubmit: (e: Event) => void;
   export let onNameInput: (e: Event) => void;
+  export let disabled = false;
 
   let rsvpOptions: { value: RsvpStatus; label: string }[] = [
     { value: "going", label: "Going" },
@@ -56,6 +57,7 @@
 
   <button
     type="submit"
+    {disabled}
     class="self-start rounded bg-primary px-6 py-2 font-bold text-white shadow transition-colors hover:bg-primary-dark disabled:cursor-not-allowed disabled:bg-gray-400"
     >Submit</button
   >

--- a/client/src/routes/create-event/+page.svelte
+++ b/client/src/routes/create-event/+page.svelte
@@ -9,6 +9,7 @@
   let location = "";
   let startTime = "";
   let endTime = "";
+  let registrationOpensAtLocal = "";
   let loading = false;
   let createdEventId: string | null = null;
   let authError = false;
@@ -44,17 +45,14 @@
     }
     loading = true;
     try {
+      const body: Record<string, unknown> = { name, date, startTime, endTime, maxAttendees, location };
+      if (registrationOpensAtLocal) {
+        body.registrationOpensAt = new Date(registrationOpensAtLocal).toISOString();
+      }
       const response = await adminFetch(`${API_HOST}/admin/create-event`, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({
-          name,
-          date,
-          startTime,
-          endTime,
-          maxAttendees,
-          location,
-        }),
+        body: JSON.stringify(body),
       });
       const data = await response.json();
       if (response.ok) {
@@ -67,6 +65,7 @@
         endTime = "";
         maxAttendees = "";
         location = "";
+        registrationOpensAtLocal = "";
         // Optionally, you could also focus the first input
       } else {
         alert(data.error || "Failed to create event.");
@@ -172,6 +171,17 @@
           aria-required="true"
           class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
         />
+      </div>
+      <div>
+        <label for="registrationOpensAt" class="mb-1 block font-semibold">Registration Opens At</label>
+        <input
+          id="registrationOpensAt"
+          name="registrationOpensAt"
+          type="datetime-local"
+          bind:value={registrationOpensAtLocal}
+          class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
+        />
+        <p class="mt-1 text-xs text-gray-500">Leave empty to open registration immediately. Admins can always register early.</p>
       </div>
       <div>
         <label for="maxAttendees" class="mb-1 block font-semibold"

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -6,7 +6,7 @@
   import { getUser } from "../../../utils/getUser";
   import AttendeeList from "$lib/AttendeeList.svelte";
   import RSVPForm from "$lib/RSVPForm.svelte";
-  import { onMount } from "svelte";
+  import { onMount, onDestroy } from "svelte";
   import { getTotalAttendance } from "../../../utils/getTotalAttendance";
   import { hasUserResponded } from "../../../utils/hasUserResponded";
   import type {User} from "../../../types/User";
@@ -33,9 +33,10 @@
     token?: string
   };
 
-  export let data: { event: Event; rsvp: Rsvp[]; poll: Poll | null };
+  export let data: { event: Event; rsvp: Rsvp[]; poll: Poll | null; clockOffset: number };
   const event = data.event;
   let poll: Poll | null = data.poll;
+  const clockOffset = data.clockOffset ?? 0;
 
   let attendees = data.rsvp;
   $: goingCount = getTotalAttendance(attendees);
@@ -52,6 +53,43 @@
   let users: User[] | undefined;
   let isAdmin = false;
   let mounted = false;
+  let registrationOpen = !event.registration_opens_at;
+  let publicRegistrationOpen = !event.registration_opens_at;
+  let countdown = '';
+  let countdownInterval: ReturnType<typeof setInterval> | null = null;
+
+  function startCountdown() {
+    if (!event.registration_opens_at) {
+      registrationOpen = true;
+      publicRegistrationOpen = true;
+      return;
+    }
+    if (isAdmin) registrationOpen = true;
+    const opensAt = new Date(event.registration_opens_at);
+    function tick() {
+      const diff = opensAt.getTime() - (Date.now() + clockOffset);
+      if (diff <= 0) {
+        registrationOpen = true;
+        publicRegistrationOpen = true;
+        countdown = '';
+        if (countdownInterval) clearInterval(countdownInterval);
+        return;
+      }
+      publicRegistrationOpen = false;
+      const totalSec = Math.floor(diff / 1000);
+      const d = Math.floor(totalSec / 86400);
+      const h = Math.floor((totalSec % 86400) / 3600);
+      const m = Math.floor((totalSec % 3600) / 60);
+      const s = totalSec % 60;
+      // Intl.DurationFormat not yet typed in TS; cast until types ship
+      countdown = new (Intl as any).DurationFormat(navigator.language, { style: 'digital' })
+        .format({ days: d, hours: h, minutes: m, seconds: s });
+    }
+    tick();
+    countdownInterval = setInterval(tick, 1000);
+  }
+
+  onDestroy(() => { if (countdownInterval) clearInterval(countdownInterval); });
 
   async function removeStaleLocalStorageEntries(eventId: string) {
     const users = getAllUsersForEvent(eventId);
@@ -104,6 +142,8 @@
       isAdmin = res.ok;
     }).catch(() => {
       isAdmin = false;
+    }).finally(() => {
+      startCountdown();
     });
 
     // import the web component only in the browser
@@ -121,28 +161,28 @@
         token: user?.token
       };
 
+      const isAdminEarlyAccess = isAdmin && !!event.registration_opens_at && new Date() < new Date(event.registration_opens_at);
       if (user?.id) {
-        await fetch(`${API_HOST}/events/${event.id}/rsvp/${user.id}`, {
+        const res = await fetch(`${API_HOST}/events/${event.id}/rsvp/${user.id}`, {
           method: "PATCH",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
+        if (!res.ok) return;
       } else {
-        const response = await fetch(`${API_HOST}/events/${event.id}/rsvp`, {
+        const rsvpFetch = isAdminEarlyAccess ? adminFetch : fetch;
+        const response = await rsvpFetch(`${API_HOST}/events/${event.id}/rsvp`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
           body: JSON.stringify(body),
         });
 
-        if (response.ok) {
-          const data = await response.json();
+        if (!response.ok) return;
 
-          if(data.rsvp) {
-            addNewRsvp(data.rsvp)
-            user = getUser(event.id)
-
-          }
-
+        const data = await response.json();
+        if (data.rsvp) {
+          addNewRsvp(data.rsvp);
+          user = getUser(event.id);
         }
       }
 
@@ -256,6 +296,32 @@
 
     <AttendeeList {attendees} maxAttendees={event.max_attendees} onDelete={onDeleteAttendee} showDeleteButton={isAdmin} />
 
+    {#if !registrationOpen}
+      <div class="mb-4 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 px-4 py-4 text-center">
+        <p class="text-lg font-semibold text-yellow-800 dark:text-yellow-200">
+          Registration opens in <span class="font-mono">{countdown}</span>
+        </p>
+        {#if event.registration_opens_at}
+          <p class="mt-1 text-sm text-yellow-700 dark:text-yellow-300">
+            {new Date(event.registration_opens_at).toLocaleString()}
+          </p>
+        {/if}
+      </div>
+    {/if}
+
+    {#if isAdmin && !publicRegistrationOpen}
+      <div class="mb-4 rounded-lg bg-blue-50 dark:bg-blue-900/20 border border-blue-200 dark:border-blue-700 px-4 py-3 text-center">
+        <p class="text-sm font-semibold text-blue-800 dark:text-blue-200">
+          Public registration opens in <span class="font-mono">{countdown}</span>
+        </p>
+        {#if event.registration_opens_at}
+          <p class="mt-1 text-xs text-blue-700 dark:text-blue-300">
+            {new Date(event.registration_opens_at).toLocaleString()}
+          </p>
+        {/if}
+      </div>
+    {/if}
+
     <PollWidget {poll} {user} {isAdmin} eventId={event.id} />
 
     {#if users && users.length > 1}
@@ -287,6 +353,7 @@
         bind:attendeeName
         onSubmit={handleRsvpSubmit}
         onNameInput={e => attendeeName = (e.target as HTMLInputElement)?.value}
+        disabled={!registrationOpen}
       />
     {:else if status !== undefined}
       {#if rsvp === 'going' && isUserOnWaitlist(attendees, user?.id ?? '', event.max_attendees)}

--- a/client/src/routes/events/[id]/+page.ts
+++ b/client/src/routes/events/[id]/+page.ts
@@ -2,10 +2,15 @@ import { API_HOST } from "../../../utils/apiHost";
 
 export const load = async ({ params, fetch }) => {
   const id = params.id;
+  const t1 = Date.now();
   const res = await fetch(`${API_HOST}/events/${id}`);
+  const t2 = Date.now();
   if (!res.ok) {
     return { event: null };
   }
   const data = await res.json();
-  return { event: data.event, rsvp: data.rsvp, poll: data.poll ?? null };
+  const clockOffset = typeof data.serverTime === 'number'
+    ? data.serverTime - (t1 + (t2 - t1) / 2)
+    : 0;
+  return { event: data.event, rsvp: data.rsvp, poll: data.poll ?? null, clockOffset };
 };

--- a/client/src/routes/events/[id]/edit/+page.svelte
+++ b/client/src/routes/events/[id]/edit/+page.svelte
@@ -13,6 +13,7 @@
   let location = "";
   let startTime = "";
   let endTime = "";
+  let registrationOpensAt = "";
   let loading = false;
   let fetchLoading = true;
   let authError = false;
@@ -44,6 +45,11 @@
       endTime = event.end_time ?? "";
       maxAttendees = event.max_attendees ?? "";
       location = event.location;
+      if (event.registration_opens_at) {
+        const d = new Date(event.registration_opens_at);
+        const pad = (n: number) => String(n).padStart(2, '0');
+        registrationOpensAt = `${d.getFullYear()}-${pad(d.getMonth()+1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+      }
     } catch {
       fetchError = "Failed to load event.";
     } finally {
@@ -66,11 +72,11 @@
       const response = await adminFetch(`${API_HOST}/admin/events/${eventId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, date, startTime, endTime, maxAttendees: maxAttendees === "" ? null : maxAttendees, location }),
+        body: JSON.stringify({ name, date, startTime, endTime, maxAttendees: maxAttendees === "" ? null : maxAttendees, location, registrationOpensAt: registrationOpensAt ? new Date(registrationOpensAt).toISOString() : null }),
       });
       const data = await response.json();
       if (response.ok) {
-        goto(`/events/${eventId}`);
+        goto(`/events/${eventId}`, { invalidateAll: true });
       } else {
         alert(data.error || "Failed to update event.");
       }
@@ -189,6 +195,16 @@
           bind:value={location}
           required
           aria-required="true"
+          class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
+        />
+      </div>
+      <div>
+        <label for="registrationOpensAt" class="mb-1 block font-semibold">Registration Opens At</label>
+        <input
+          id="registrationOpensAt"
+          name="registrationOpensAt"
+          type="datetime-local"
+          bind:value={registrationOpensAt}
           class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
         />
       </div>

--- a/client/src/types/Event.ts
+++ b/client/src/types/Event.ts
@@ -7,4 +7,5 @@ export type Event = {
   max_attendees: number;
   location: string;
   created_at?: string;
+  registration_opens_at?: string;
 };

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -50,12 +50,12 @@ export const getAllEvents = async (req: Request, res: Response, next: Function) 
 
 export const updateEvent = async (req: Request, res: Response, next: Function) => {
   const { id } = req.params;
-  const { name, date, startTime, endTime, maxAttendees, location } = req.body;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = req.body;
   if (endTime && startTime && endTime <= startTime) {
     return res.status(400).json({ error: "endTime must be after startTime." });
   }
   try {
-    const event = await updateEventService(id, { name, date, startTime, endTime, maxAttendees, location });
+    const event = await updateEventService(id, { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt });
     if (!event) {
       return res.status(404).json({ error: "Event not found" });
     }

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -4,7 +4,7 @@ import { getRsvpByEventId } from '../services/rsvp';
 import { getPollByEventId } from '../services/poll';
 
 export const createEvent = async (req: Request, res: Response, next: Function) => {
-  const { name, date, startTime, endTime, maxAttendees, location } = req.body;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = req.body;
   if (!name || !date || !location || !startTime || !endTime) {
     return res.status(400).json({ error: "Name, date, startTime, endTime, and location are required." });
   }
@@ -12,7 +12,7 @@ export const createEvent = async (req: Request, res: Response, next: Function) =
     return res.status(400).json({ error: "endTime must be after startTime." });
   }
   try {
-    const event = await createEventService({ name, date, startTime, endTime, maxAttendees, location });
+    const event = await createEventService({ name, date, startTime, endTime, maxAttendees, location, registrationOpensAt });
     res.status(201).json({
       message: "Event created successfully!",
       event
@@ -33,7 +33,7 @@ export const getEventById = async (req: Request, res: Response, next: Function) 
     // Fetch attendees for this event using the service
     const attendees = await getRsvpByEventId(id);
     const poll = getPollByEventId(id);
-    res.status(200).json({ event, rsvp: attendees, poll });
+    res.status(200).json({ event, rsvp: attendees, poll, serverTime: Date.now() });
   } catch (err) {
     next(err);
   }

--- a/server/src/controllers/rsvpController.ts
+++ b/server/src/controllers/rsvpController.ts
@@ -1,8 +1,9 @@
 import { Request, Response } from "express";
 import { deleteRsvpById, rsvpToEventService, updateRsvpByToken } from "../services/rsvp";
+import { getEventById as getEventByIdService } from "../services/event";
 import { isValidStatus } from "../validators/isValidStatus";
 import { getMyRsvpsService } from '../services/rsvp';
-
+import { isAdminRequest } from "../middlewares/auth";
 
 export const rsvpToEvent = async (req: Request, res: Response, next: Function) => {
   try {
@@ -17,8 +18,19 @@ export const rsvpToEvent = async (req: Request, res: Response, next: Function) =
       return res.status(400).json({ error: "Invalid RSVP status. Must be 'going', 'not_going', or 'maybe'." });
     }
 
+    const event = await getEventByIdService(eventId);
+    if (!event) {
+      return res.status(404).json({ error: "Event not found." });
+    }
+
+    const registrationOpensAt = (event as any).registration_opens_at as string | null;
+    if (registrationOpensAt && Date.now() < new Date(registrationOpensAt).getTime() - 1000) {
+      if (!isAdminRequest(req)) {
+        return res.status(403).json({ error: "Registration not yet open.", registrationOpensAt });
+      }
+    }
+
     if (!attendeeId) {
-      // Generate a new UUID for attendeeId if not provided
       attendeeId = require('uuid').v4();
     }
 

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -11,6 +11,16 @@ function migrationAddTokenColumnToRsvp() {
   }
 }
 
+// Migration: Add registration_opens_at column to events if missing
+function migrationAddRegistrationOpensAtToEvents() {
+  type PragmaColumn = { name: string };
+  const pragma = db.prepare("PRAGMA table_info(events);").all() as PragmaColumn[];
+  if (!pragma.some(col => col.name === 'registration_opens_at')) {
+    db.prepare("ALTER TABLE events ADD COLUMN registration_opens_at TEXT;").run();
+    console.log("Added 'registration_opens_at' column to events table.");
+  }
+}
+
 // Seeds the SQLite database with required tables
 export default function seed() {
   try {
@@ -45,6 +55,7 @@ export default function seed() {
     `).run();
 
     migrationAddTokenColumnToRsvp();
+    migrationAddRegistrationOpensAtToEvents();
 
     // Create polls table
     db.prepare(`

--- a/server/src/middlewares/auth.ts
+++ b/server/src/middlewares/auth.ts
@@ -1,17 +1,15 @@
 import { Request, Response, NextFunction } from 'express';
 import config from '../config';
 
-// Middleware to authenticate admin using 'Basic USER:PASS' from Authorization header
-export function authenticateAdmin(req: Request, res: Response, next: NextFunction) {
+export function isAdminRequest(req: Request): boolean {
   const authHeader = req.headers['authorization'];
-  if (!authHeader || !authHeader.startsWith('Basic ')) {
+  if (!authHeader || !authHeader.startsWith('Basic ')) return false;
+  return authHeader.replace('Basic ', '') === `${config.ADMIN_USER}:${config.ADMIN_PASSWORD}`;
+}
+
+export function authenticateAdmin(req: Request, res: Response, next: NextFunction) {
+  if (!isAdminRequest(req)) {
     return res.status(401).json({ error: 'Authorization header missing or invalid' });
-  }
-  const credentials = authHeader.replace('Basic ', '');
-  if (
-    credentials !== `${config.ADMIN_USER}:${config.ADMIN_PASSWORD}`
-  ) {
-    return res.status(403).json({ error: 'Invalid credentials' });
   }
   next();
 }

--- a/server/src/services/event.ts
+++ b/server/src/services/event.ts
@@ -6,11 +6,11 @@ import { v4 as uuidv4 } from 'uuid';
 export function createEvent(event: Omit<Event, 'id' | 'createdAt'>): Event {
   const id = uuidv4();
   const createdAt = new Date().toISOString();
-  const { name, date, startTime, endTime, maxAttendees, location } = event;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = event;
   db.prepare(`
-    INSERT INTO events (id, name, date, start_time, end_time, max_attendees, location, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, name, date, startTime, endTime || null, maxAttendees ?? null, location, createdAt);
+    INSERT INTO events (id, name, date, start_time, end_time, max_attendees, location, created_at, registration_opens_at)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, name, date, startTime, endTime || null, maxAttendees ?? null, location, createdAt, registrationOpensAt ?? null);
   return db.prepare('SELECT * FROM events WHERE id = ?').get(id) as Event;
 }
 

--- a/server/src/services/event.ts
+++ b/server/src/services/event.ts
@@ -29,7 +29,7 @@ export function deleteEvent(id: string): boolean {
 export function updateEvent(id: string, updates: Partial<Omit<Event, 'id' | 'createdAt'>>): Event | null {
   const existing = getEventById(id);
   if (!existing) return null;
-  const { name, date, startTime, endTime, maxAttendees, location } = updates;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = updates;
   db.prepare(`
     UPDATE events SET
       name = COALESCE(?, name),
@@ -37,7 +37,8 @@ export function updateEvent(id: string, updates: Partial<Omit<Event, 'id' | 'cre
       start_time = COALESCE(?, start_time),
       end_time = COALESCE(?, end_time),
       max_attendees = CASE WHEN ? = 1 THEN ? ELSE max_attendees END,
-      location = COALESCE(?, location)
+      location = COALESCE(?, location),
+      registration_opens_at = CASE WHEN ? = 1 THEN ? ELSE registration_opens_at END
     WHERE id = ?
   `).run(
     name ?? null,
@@ -47,6 +48,8 @@ export function updateEvent(id: string, updates: Partial<Omit<Event, 'id' | 'cre
     maxAttendees !== undefined ? 1 : 0,
     maxAttendees ?? null,
     location ?? null,
+    registrationOpensAt !== undefined ? 1 : 0,
+    registrationOpensAt ?? null,
     id
   );
   return db.prepare('SELECT * FROM events WHERE id = ?').get(id) as Event;

--- a/server/src/types/Event.ts
+++ b/server/src/types/Event.ts
@@ -7,5 +7,6 @@ export type Event = {
   maxAttendees?: number;
   location: string;
   createdAt?: string; // ISO date string (YYYY-MM-DDTHH:mm:ss.sssZ)
+  registrationOpensAt?: string; // ISO UTC datetime — when public registration opens
 };
 


### PR DESCRIPTION
Events can be created with an optional registration open time. Registration is blocked until that time. Admins can always register.

Event page shows a live countdown and the submit button is disabled until registration opens. Admins also see the countdown as an info banner.

The server sends its current time to the client so the countdown is based on the server clock rather than the local clock, preventing submissions from being rejected due to clock skew at the moment of opening. The server also accepts submissions one second early to absorb latency.

RSVP submit now checks response.ok before showing the success toast or updating local state.