### PR TITLE
Bump better-sqlite3 to ^12.10.0 for Node v26 compatibility

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -3,7 +3,7 @@
   "packageManager": "yarn@4.9.2",
   "dependencies": {
     "@types/dotenv": "^8.2.3",
-    "better-sqlite3": "^12.2.0",
+    "better-sqlite3": "^12.10.0",
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -338,14 +338,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"better-sqlite3@npm:^12.2.0":
-  version: 12.2.0
-  resolution: "better-sqlite3@npm:12.2.0"
+"better-sqlite3@npm:^12.10.0":
+  version: 12.10.0
+  resolution: "better-sqlite3@npm:12.10.0"
   dependencies:
     bindings: "npm:^1.5.0"
     node-gyp: "npm:latest"
     prebuild-install: "npm:^7.1.1"
-  checksum: 10c0/842247e9bbb775f366ac91f604117112c312497e643bac21648d8b69f479763de0ac049b14b609d6d5ecaee50debcc09a854f682d3dc099a1d933fea92ce68d0
+  checksum: 10c0/b269792c1e456201b16fb9abd1e3fa9284d7710929f991899cebbb61e56dc3703673be29dadcb2f4a2d02961c49145f53d7d7b13b7b47298c033ec9de524f34f
   languageName: node
   linkType: hard
 
@@ -1589,7 +1589,7 @@ __metadata:
     "@types/dotenv": "npm:^8.2.3"
     "@types/express": "npm:^5.0.3"
     "@types/node": "npm:^24.2.1"
-    better-sqlite3: "npm:^12.2.0"
+    better-sqlite3: "npm:^12.10.0"
     cors: "npm:^2.8.5"
     dotenv: "npm:^17.2.1"
     express: "npm:^5.1.0"


### PR DESCRIPTION
12.2.0 has no prebuilds for Node v26 (ABI 147) and source compilation fails with hard errors on removed V8 APIs (GetPrototype, GetIsolate, This in PropertyCallbackInfo). 12.10.0 is the first release to ship Node v26 prebuilds, so yarn install no longer falls back to a broken source build.