### PR TITLE
Fix My RSVPs crash and show per-attendee status for group RSVPs

### DIFF
--- a/client/src/routes/my/rsvps/+page.svelte
+++ b/client/src/routes/my/rsvps/+page.svelte
@@ -7,11 +7,28 @@ import type {Event} from "../../../types/Event";
 import {formatDate} from "../../../utils/format";
 import { splitAndSortByEvent, type Group } from "../../../utils/sortAndGroupEvents";
 
+type Attendee = {
+  name: string;
+  status: RsvpStatus;
+};
+
 type Rsvp = {
   event: Event;
   yourStatus: RsvpStatus;
+  attendees?: Attendee[];
   isLast?: boolean;
 };
+
+function statusColor(s: RsvpStatus) {
+  return s === 'going' ? 'bg-green-100 text-green-700'
+       : s === 'maybe' ? 'bg-yellow-100 text-yellow-700'
+       : s === 'not_going' ? 'bg-red-100 text-red-700'
+       : 'bg-gray-200 text-gray-500';
+}
+
+function formatStatus(s: RsvpStatus) {
+  return s ? s.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase()) : 'No Status';
+}
 
 let loading = true;
 let rsvps: Rsvp[] = [];
@@ -37,7 +54,23 @@ onMount(async () => {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ myRsvps })
     });
-    rsvps = (await res.json()).rsvps || [];
+    const allRsvps = (await res.json()).rsvps || [];
+    const byEvent = new Map<string, any[]>();
+    for (const r of allRsvps) {
+      if (!byEvent.has(r.event.id)) byEvent.set(r.event.id, []);
+      byEvent.get(r.event.id)!.push(r);
+    }
+    rsvps = Array.from(byEvent.values()).map(group => {
+      const first = group[0];
+      const hasNames = group.some((r: any) => r.attendeeName);
+      return {
+        event: first.event,
+        yourStatus: first.yourStatus,
+        ...(hasNames && group.length > 1 && {
+          attendees: group.map((r: any) => ({ name: r.attendeeName, status: r.yourStatus as RsvpStatus })),
+        }),
+      };
+    });
     groups = splitAndSortByEvent(rsvps);
     flagLastRsvp(groups);
   } catch (err) {
@@ -62,16 +95,26 @@ onMount(async () => {
     <div class="w-full flex flex-col items-center gap-4">
       {#each groups as { title, items }}
         <h2 class="text-xl font-semibold mt-4">{title}</h2>
-        {#each items as { event, yourStatus, isLast } (event.id)}
+        {#each items as { event, yourStatus, attendees, isLast } (event.id)}
           <a
             href={`/events/${event.id}`}
             class="w-full max-w-md bg-gray-50 dark:bg-gray-900 rounded-lg shadow p-5 flex flex-col gap-2 transition hover:shadow-lg hover:ring-2 hover:ring-primary cursor-pointer {isLast ? 'mb-5' : ''}"
           >
-            <div class="flex items-center justify-between">
-              <span class="text-xl font-semibold text-primary">{event.name}</span>
-              <span class="px-3 py-1 rounded text-sm font-bold {yourStatus === 'going' ? 'bg-green-100 text-green-700' : yourStatus === 'maybe' ? 'bg-yellow-100 text-yellow-700' : yourStatus === 'not_going' ? 'bg-red-100 text-red-700' : 'bg-gray-200 text-gray-500'}">
-                {yourStatus ? yourStatus.replace('_', ' ').replace(/\b\w/g, c => c.toUpperCase()) : 'No Status'}
-              </span>
+            <div class="flex items-start justify-between gap-2">
+              <span class="min-w-0 text-xl font-semibold text-primary">{event.name}</span>
+              {#if attendees}
+                <div class="flex flex-col gap-1 items-end min-w-0">
+                  {#each attendees as a}
+                    <span class="px-2 py-0.5 rounded text-xs font-bold min-w-0 break-all text-right {statusColor(a.status)}">
+                      {a.name}: {formatStatus(a.status)}
+                    </span>
+                  {/each}
+                </div>
+              {:else}
+                <span class="px-3 py-1 rounded text-sm font-bold {statusColor(yourStatus)}">
+                  {formatStatus(yourStatus)}
+                </span>
+              {/if}
             </div>
             <div class="text-gray-600 dark:text-gray-300 text-sm">
               <span class="font-medium">Date:</span> {formatDate(event.date)}<br />

--- a/server/src/services/rsvp.ts
+++ b/server/src/services/rsvp.ts
@@ -42,15 +42,14 @@ export async function getMyRsvpsService(pairs: { rsvpId: string, eventId: string
   const wherePairs = pairs.map(() => '(?, ?)').join(', ');
   const flatParams = pairs.flatMap(({ rsvpId, eventId }) => [rsvpId, eventId]);
   const sql = `
-    SELECT e.*, r.status as your_status
+    SELECT e.*, r.status as your_status, r.name as rsvp_name
     FROM rsvp r
     JOIN events e ON r.event_id = e.id
     WHERE (r.id, r.event_id) IN (${wherePairs})
   `;
   const rows = db.prepare(sql).all(...flatParams);
-  // Return as { event, yourStatus }
   return rows.map(row => {
-    const { your_status, ...event } = row as any;
-    return { event, yourStatus: your_status };
+    const { your_status, rsvp_name, ...event } = row as any;
+    return { event, yourStatus: your_status, attendeeName: rsvp_name };
   });
 }


### PR DESCRIPTION
Fixes an each_key_duplicate crash when the same event had multiple RSVPs stored (from the +1 button). Groups RSVPs by event client-side using a Map, then shows each attendee's name and status as stacked badges when there are multiple.