### PR TITLE
Add server unit tests with Vitest

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -43,6 +43,20 @@ SQLITE_DB_PATH=./data/event_rsvp.db # optional, default is ./data/event_rsvp.db
 - `GET    /events/:id` — Get event by ID
 - `POST   /events/:id/rsvp` — RSVP to an event
 
+## Testing
+
+Run the unit test suite:
+```sh
+yarn test
+```
+
+Run in watch mode during development:
+```sh
+yarn test:watch
+```
+
+Tests live in `src/__tests__/unit/` and cover middleware, services, and validators.
+
 ## Notes
 - All admin routes require a Basic Authorization header: `Basic USER:PASS` (credentials from `.env`).
 - Uses SQLite for storage (no external DB required).

--- a/server/package.json
+++ b/server/package.json
@@ -15,12 +15,17 @@
     "@types/cors": "^2",
     "@types/express": "^5.0.3",
     "@types/node": "^24.2.1",
+    "@vitest/coverage-v8": "^4.1.6",
     "ts-node": "^10.9.2",
-    "typescript": "^5.9.2"
+    "typescript": "^5.9.2",
+    "vitest": "^4.1.6"
   },
   "scripts": {
     "dev": "ts-node src/index.ts",
     "build": "tsc --build",
-    "start": "node dist/index.js"
+    "start": "node dist/index.js",
+    "test": "vitest run",
+    "test:watch": "vitest",
+    "test:coverage": "vitest run --coverage"
   }
 }

--- a/server/src/__tests__/setup.ts
+++ b/server/src/__tests__/setup.ts
@@ -1,0 +1,8 @@
+import { beforeAll, vi } from 'vitest';
+import seed from '../db/seed';
+
+beforeAll(() => {
+  const spy = vi.spyOn(console, 'log').mockImplementation(() => {});
+  seed();
+  spy.mockRestore();
+});

--- a/server/src/__tests__/unit/middleware/auth.test.ts
+++ b/server/src/__tests__/unit/middleware/auth.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it, vi } from 'vitest';
+import { authenticateAdmin, isAdminRequest } from '../../../middlewares/auth';
+import type { NextFunction, Request, Response } from 'express';
+
+// ⚠️ WARNING: this is NOT real HTTP Basic Auth, and the tests below pin the
+// broken behavior on purpose (so a fix shows up as an intentional change, not a
+// silent regression). Two things are wrong with the implementation:
+//
+//   1. NON-STANDARD ENCODING. RFC 7617 ("HTTP Basic auth") requires the header
+//      to be `Authorization: Basic base64("user:pass")`. This code instead sends
+//      and compares the *raw* `user:pass` string after stripping "Basic ". It
+//      only works because the client is broken in the exact same way. A standards
+//      -compliant proxy/CDN/browser, or any `:`/space/`%` in the credentials,
+//      breaks it. The fix is to base64-encode/decode the credentials.
+//   2. NOT CONSTANT-TIME. The compare uses `===`, which short-circuits on the
+//      first differing byte and leaks timing information about the secret. A real
+//      implementation should use `crypto.timingSafeEqual` (after a length check).
+//
+// When either is fixed, expect the assertions in this file to change.
+
+// Credentials as set in vitest.config.ts env
+const VALID = 'Basic testadmin:testpass';
+const WRONG_PASS = 'Basic testadmin:wrong';
+const WRONG_SCHEME = 'Bearer testadmin:testpass';
+
+function req(authorization?: string): Request {
+  return { headers: authorization ? { authorization } : {} } as unknown as Request;
+}
+
+function res(): Response {
+  return {
+    status: vi.fn().mockReturnThis(),
+    json: vi.fn().mockReturnThis(),
+  } as unknown as Response;
+}
+
+describe('isAdminRequest', () => {
+  it('returns true for correct credentials', () => {
+    // Note the credentials are raw, NOT base64 ("dGVzdGFkbWluOnRlc3RwYXNz").
+    // Real Basic auth would reject this raw form; this bespoke scheme requires it.
+    expect(isAdminRequest(req(VALID))).toBe(true);
+  });
+
+  it('returns false when Authorization header is absent', () => {
+    expect(isAdminRequest(req())).toBe(false);
+  });
+
+  it('returns false for wrong password', () => {
+    expect(isAdminRequest(req(WRONG_PASS))).toBe(false);
+  });
+
+  it('returns false for non-Basic scheme', () => {
+    expect(isAdminRequest(req(WRONG_SCHEME))).toBe(false);
+  });
+
+  it.each([
+    ['no space after Basic', 'Basic'],
+    ['space but no credentials', 'Basic '],
+    ['leading space before Basic', ' Basic testadmin:testpass'],
+  ])('returns false for malformed header: %s', (_, header) => {
+    expect(isAdminRequest(req(header))).toBe(false);
+  });
+
+  it('returns false for lowercase scheme (basic ...)', () => {
+    expect(isAdminRequest(req('basic testadmin:testpass'))).toBe(false);
+  });
+
+  it('returns false when password contains a colon (mismatched credentials)', () => {
+    // header: Basic testadmin:pa:ss — replace('Basic ','') yields testadmin:pa:ss
+    // which does not equal testadmin:testpass
+    expect(isAdminRequest(req('Basic testadmin:pa:ss'))).toBe(false);
+  });
+
+  it('returns false for prefix duplication (Basic Basic ...)', () => {
+    // replace('Basic ','') is not global — yields 'Basic testadmin:testpass'
+    expect(isAdminRequest(req('Basic Basic testadmin:testpass'))).toBe(false);
+  });
+
+  it('returns false for empty password (Basic testadmin:)', () => {
+    expect(isAdminRequest(req('Basic testadmin:'))).toBe(false);
+  });
+
+  it('returns false when credentials have trailing whitespace', () => {
+    expect(isAdminRequest(req('Basic testadmin:testpass '))).toBe(false);
+  });
+});
+
+describe('authenticateAdmin', () => {
+  it('calls next() for valid credentials', () => {
+    const next = vi.fn() as unknown as NextFunction;
+    authenticateAdmin(req(VALID), res(), next);
+    expect(next).toHaveBeenCalledOnce();
+  });
+
+  it('returns 401 and does not call next() for missing credentials', () => {
+    const next = vi.fn() as unknown as NextFunction;
+    const r = res();
+    authenticateAdmin(req(), r, next);
+    expect(r.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+
+  it('returns 401 for wrong password', () => {
+    const next = vi.fn() as unknown as NextFunction;
+    const r = res();
+    authenticateAdmin(req(WRONG_PASS), r, next);
+    expect(r.status).toHaveBeenCalledWith(401);
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/server/src/__tests__/unit/services/eventService.test.ts
+++ b/server/src/__tests__/unit/services/eventService.test.ts
@@ -1,0 +1,158 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import {
+  createEvent,
+  deleteEvent,
+  getAllEvents,
+  getEventById,
+  updateEvent,
+} from '../../../services/event';
+import db from '../../../db';
+
+// TYPE DRIFT (documented, not fixed): the services do `SELECT *` and return raw
+// snake_case DB rows, but the server's `types/Event.ts` is camelCase
+// (startTime, maxAttendees, registrationOpensAt...). So the declared return type
+// lies about the real shape. These tests assert against the *actual* wire/DB
+// shape via this local snake_case type and `as unknown as DbEvent` casts. The
+// proper fix is to split a snake_case RawEventRow from the camelCase app Event
+// and map between them (or commit to snake_case end to end).
+type DbEvent = { id: string; name: string; location: string; max_attendees: number | null; registration_opens_at: string | null };
+
+const BASE = {
+  name: 'Test Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Test Venue',
+};
+
+beforeEach(() => {
+  db.prepare('DELETE FROM events').run();
+});
+
+describe('createEvent', () => {
+  it('creates an event and returns it with a generated id', () => {
+    const event = createEvent(BASE) as unknown as DbEvent;
+    expect(event.id).toBeTruthy();
+    expect(event.name).toBe('Test Event');
+    expect(event.location).toBe('Test Venue');
+  });
+
+  it('stores maxAttendees', () => {
+    const event = createEvent({ ...BASE, maxAttendees: 30 }) as unknown as DbEvent;
+    expect(event.max_attendees).toBe(30);
+  });
+
+  it('stores registrationOpensAt', () => {
+    const opensAt = '2025-11-01T09:00:00.000Z';
+    const event = createEvent({ ...BASE, registrationOpensAt: opensAt }) as unknown as DbEvent;
+    expect(event.registration_opens_at).toBe(opensAt);
+  });
+
+  it('defaults max_attendees to null when not provided', () => {
+    const event = createEvent(BASE) as unknown as DbEvent;
+    expect(event.max_attendees).toBeNull();
+  });
+
+  it('accepts a whitespace-only name (validation is a controller-level concern)', () => {
+    const event = createEvent({ ...BASE, name: '   ' }) as unknown as DbEvent;
+    expect(event.name).toBe('   ');
+  });
+
+  it('round-trips a name containing emoji and 4-byte Unicode', () => {
+    const name = '🎉 Board Game Night 🃏 — مرحبا 你好';
+    const event = createEvent({ ...BASE, name }) as unknown as DbEvent;
+    expect(event.name).toBe(name);
+  });
+
+  it('round-trips a name containing RTL text', () => {
+    const name = 'אירוע גיימינג';
+    const event = createEvent({ ...BASE, name }) as unknown as DbEvent;
+    expect(event.name).toBe(name);
+  });
+});
+
+describe('getEventById', () => {
+  it('retrieves an event by its id', () => {
+    const created = createEvent(BASE);
+    const found = getEventById(created.id);
+    expect(found).not.toBeNull();
+    expect(found!.id).toBe(created.id);
+  });
+
+  it('returns null for a non-existent id', () => {
+    expect(getEventById('no-such-id')).toBeNull();
+  });
+});
+
+describe('getAllEvents', () => {
+  it('returns all events and orders by created_at descending', () => {
+    // Insert with explicit timestamps to guarantee ordering
+    const now = new Date();
+    const older = new Date(now.getTime() - 1000).toISOString();
+    const newer = now.toISOString();
+    db.prepare(
+      `INSERT INTO events (id, name, date, start_time, end_time, location, created_at) VALUES ('id-1', 'First', '2025-12-25', '18:00', '22:00', 'Venue', ?)`,
+    ).run(older);
+    db.prepare(
+      `INSERT INTO events (id, name, date, start_time, end_time, location, created_at) VALUES ('id-2', 'Second', '2025-12-25', '18:00', '22:00', 'Venue', ?)`,
+    ).run(newer);
+    const events = getAllEvents();
+    expect(events).toHaveLength(2);
+    expect(events[0].name).toBe('Second');
+    expect(events[1].name).toBe('First');
+  });
+
+  it('returns an empty array when there are no events', () => {
+    expect(getAllEvents()).toEqual([]);
+  });
+});
+
+describe('updateEvent', () => {
+  it('updates name while leaving other fields intact', () => {
+    const created = createEvent(BASE);
+    const updated = updateEvent(created.id, { name: 'Renamed Event' });
+    expect(updated!.name).toBe('Renamed Event');
+    expect(updated!.location).toBe('Test Venue');
+  });
+
+  it('can clear maxAttendees by passing null', () => {
+    const created = createEvent({ ...BASE, maxAttendees: 50 });
+    const updated = updateEvent(created.id, { maxAttendees: null as any }) as unknown as DbEvent;
+    expect(updated!.max_attendees).toBeNull();
+  });
+
+  it('can clear registrationOpensAt by passing null', () => {
+    const created = createEvent({ ...BASE, registrationOpensAt: '2025-11-01T09:00:00.000Z' });
+    const updated = updateEvent(created.id, { registrationOpensAt: null as any }) as unknown as DbEvent;
+    expect(updated!.registration_opens_at).toBeNull();
+  });
+
+  it('returns null for a non-existent id', () => {
+    expect(updateEvent('ghost', { name: 'X' })).toBeNull();
+  });
+
+  it('clearing maxAttendees to null is reflected on next read', () => {
+    const created = createEvent({ ...BASE, maxAttendees: 5 }) as unknown as DbEvent;
+    updateEvent(created.id, { maxAttendees: null as any });
+    const reread = getEventById(created.id) as unknown as DbEvent;
+    expect(reread!.max_attendees).toBeNull();
+  });
+
+  it('shrinking maxAttendees below existing count is accepted by the service', () => {
+    const created = createEvent({ ...BASE, maxAttendees: 10 });
+    const updated = updateEvent(created.id, { maxAttendees: 1 }) as unknown as DbEvent;
+    expect(updated!.max_attendees).toBe(1);
+  });
+});
+
+describe('deleteEvent', () => {
+  it('deletes an event and returns true', () => {
+    const created = createEvent(BASE);
+    expect(deleteEvent(created.id)).toBe(true);
+    expect(getEventById(created.id)).toBeNull();
+  });
+
+  it('returns false for a non-existent id', () => {
+    expect(deleteEvent('ghost')).toBe(false);
+  });
+});

--- a/server/src/__tests__/unit/services/pollService.test.ts
+++ b/server/src/__tests__/unit/services/pollService.test.ts
@@ -1,0 +1,238 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  castVotes,
+  closePoll,
+  createPoll,
+  deletePoll,
+  getPollByEventId,
+  reopenPoll,
+  updatePoll,
+} from '../../../services/poll';
+import { createEvent } from '../../../services/event';
+import { rsvpToEventService } from '../../../services/rsvp';
+import db from '../../../db';
+
+const BASE_EVENT = {
+  name: 'Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Venue',
+};
+
+const TWO_OPTIONS = [
+  { name: 'Option A', url: 'https://a.example.com' },
+  { name: 'Option B', url: 'https://b.example.com' },
+];
+
+// NOTE on ordering: createPoll inserts all options inside one transaction with a
+// single `now` timestamp, so they share an identical created_at. buildPoll orders
+// options by `created_at ASC`, and SQLite does NOT guarantee a stable order for
+// tied sort keys — it just happens to return them in insertion (rowid) order here.
+// Tests that index options positionally (options[0] === 'Option A', etc.) rely on
+// that. If this ever flakes, give poll_options a deterministic tiebreaker
+// (e.g. a sort_order column, or ORDER BY created_at, rowid).
+
+let eventId: string;
+let rsvpId: string;
+let rsvpToken: string;
+
+beforeEach(() => {
+  db.prepare('DELETE FROM poll_votes').run();
+  db.prepare('DELETE FROM poll_options').run();
+  db.prepare('DELETE FROM polls').run();
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+
+  eventId = createEvent(BASE_EVENT).id;
+  const rsvp = rsvpToEventService({ id: uuidv4(), eventId, name: 'Voter', status: 'going' }) as any;
+  rsvpId = rsvp.id;
+  rsvpToken = rsvp.token;
+});
+
+describe('getPollByEventId', () => {
+  it('returns null when no poll exists for the event', () => {
+    expect(getPollByEventId(eventId)).toBeNull();
+  });
+
+  it('returns the poll with empty votes on its options', () => {
+    createPoll(eventId, 'Where?', TWO_OPTIONS);
+    const poll = getPollByEventId(eventId)!;
+    expect(poll.title).toBe('Where?');
+    expect(poll.options).toHaveLength(2);
+    expect(poll.options[0].votes).toEqual([]);
+  });
+});
+
+describe('createPoll', () => {
+  it('creates a poll with status open and the given options', () => {
+    const poll = createPoll(eventId, 'When?', TWO_OPTIONS);
+    expect(poll.status).toBe('open');
+    expect(poll.event_id).toBe(eventId);
+    expect(poll.options).toHaveLength(2);
+  });
+
+  it('stores an optional description on options', () => {
+    const poll = createPoll(eventId, 'Where?', [
+      { name: 'A', url: 'https://a.example.com', description: 'Nice place' },
+    ]);
+    expect(poll.options[0].description).toBe('Nice place');
+  });
+
+  it('does NOT prevent a second poll for the same event (BUG: duplicate polls)', () => {
+    // BUG: there is no UNIQUE(event_id) constraint and createPoll does not check
+    // for an existing poll, so two polls can be created for one event. Worse,
+    // getPollByEventId uses `.get()` and silently returns only one of them, so the
+    // second poll becomes an orphaned, unreachable row. createPoll should reject a
+    // duplicate (or update the existing poll) instead of creating a second.
+    const first = createPoll(eventId, 'First', TWO_OPTIONS);
+    const second = createPoll(eventId, 'Second', TWO_OPTIONS);
+    expect(first).not.toBeNull();
+    expect(second).not.toBeNull();
+
+    const polls = db.prepare('SELECT * FROM polls WHERE event_id = ?').all(eventId);
+    expect(polls).toHaveLength(2);
+    // Only the first poll is ever reachable via the public API.
+    expect(getPollByEventId(eventId)!.title).toBe('First');
+  });
+});
+
+describe('closePoll', () => {
+  it('changes the poll status to closed', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(closePoll(poll.id)!.status).toBe('closed');
+  });
+
+  it('returns null when the poll is already closed', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    closePoll(poll.id);
+    expect(closePoll(poll.id)).toBeNull();
+  });
+
+  it('sorts options by vote count descending when closing', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    // Give Option B one vote before closing
+    castVotes(poll.id, rsvpId, rsvpToken, [poll.options[1].id]);
+    const closed = closePoll(poll.id)!;
+    expect(closed.options[0].id).toBe(poll.options[1].id);
+  });
+});
+
+describe('reopenPoll', () => {
+  it('changes the poll status back to open', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    closePoll(poll.id);
+    expect(reopenPoll(poll.id)!.status).toBe('open');
+  });
+
+  it('returns null when the poll is already open', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(reopenPoll(poll.id)).toBeNull();
+  });
+});
+
+describe('updatePoll', () => {
+  it('updates the title', () => {
+    const poll = createPoll(eventId, 'Old Title', TWO_OPTIONS);
+    const updated = updatePoll(
+      poll.id,
+      'New Title',
+      poll.options.map((o) => ({ id: o.id, name: o.name, url: o.url })),
+    )!;
+    expect(updated.title).toBe('New Title');
+  });
+
+  it('adds a new option', () => {
+    const poll = createPoll(eventId, 'Where?', TWO_OPTIONS);
+    const existing = poll.options.map((o) => ({ id: o.id, name: o.name, url: o.url }));
+    const updated = updatePoll(poll.id, 'Where?', [
+      ...existing,
+      { name: 'Option C', url: 'https://c.example.com' },
+    ])!;
+    expect(updated.options).toHaveLength(3);
+  });
+
+  it('removes an option not included in the update', () => {
+    const poll = createPoll(eventId, 'Where?', TWO_OPTIONS);
+    const keepFirst = [{ id: poll.options[0].id, name: poll.options[0].name, url: poll.options[0].url }];
+    const updated = updatePoll(poll.id, 'Where?', keepFirst)!;
+    expect(updated.options).toHaveLength(1);
+    expect(updated.options[0].id).toBe(poll.options[0].id);
+  });
+
+  it('returns null for an unknown poll id', () => {
+    expect(updatePoll('ghost', 'Title', [{ name: 'x', url: 'x' }])).toBeNull();
+  });
+});
+
+describe('deletePoll', () => {
+  it('deletes the poll and returns true', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(deletePoll(poll.id)).toBe(true);
+    expect(getPollByEventId(eventId)).toBeNull();
+  });
+
+  it('returns false for an unknown poll id', () => {
+    expect(deletePoll('ghost')).toBe(false);
+  });
+});
+
+describe('castVotes', () => {
+  it('records a vote for a valid rsvp+token', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    const result = castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id])!;
+    expect(result.options[0].votes).toHaveLength(1);
+    expect(result.options[0].votes[0].voter_name).toBe('Voter');
+  });
+
+  it('allows voting for multiple options', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    const result = castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id, poll.options[1].id])!;
+    expect(result.options[0].votes).toHaveLength(1);
+    expect(result.options[1].votes).toHaveLength(1);
+  });
+
+  it('replaces previous votes when re-voting', () => {
+    // Relies on stable option ordering (see the ordering NOTE near TWO_OPTIONS):
+    // options[0] is 'Option A', options[1] is 'Option B'.
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id]);
+    castVotes(poll.id, rsvpId, rsvpToken, [poll.options[1].id]);
+    const final = getPollByEventId(eventId)!;
+    expect(final.options[0].votes).toHaveLength(0);
+    expect(final.options[1].votes).toHaveLength(1);
+  });
+
+  it('returns null for a wrong token', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(castVotes(poll.id, rsvpId, 'wrongtoken', [poll.options[0].id])).toBeNull();
+  });
+
+  it('returns null for a closed poll', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    closePoll(poll.id);
+    expect(castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id])).toBeNull();
+  });
+
+  it('returns null when an option id does not belong to the poll', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(castVotes(poll.id, rsvpId, rsvpToken, ['invalid-option-id'])).toBeNull();
+  });
+
+  it('rejects the whole submission when any option id is invalid (mixed valid + invalid)', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(
+      castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id, 'invalid-option-id']),
+    ).toBeNull();
+    // The valid option must not have been recorded either — it is all-or-nothing.
+    expect(getPollByEventId(eventId)!.options[0].votes).toHaveLength(0);
+  });
+
+  it("rejects an option id that belongs to a different poll", () => {
+    const otherEventId = createEvent(BASE_EVENT).id;
+    const otherPoll = createPoll(otherEventId, 'Other', TWO_OPTIONS);
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
+    expect(castVotes(poll.id, rsvpId, rsvpToken, [otherPoll.options[0].id])).toBeNull();
+  });
+});

--- a/server/src/__tests__/unit/services/rsvpService.test.ts
+++ b/server/src/__tests__/unit/services/rsvpService.test.ts
@@ -1,0 +1,223 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { v4 as uuidv4 } from 'uuid';
+import {
+  deleteRsvpById,
+  getMyRsvpsService,
+  getRsvpByEventId,
+  rsvpToEventService,
+  updateRsvpByToken,
+} from '../../../services/rsvp';
+import { createEvent, deleteEvent } from '../../../services/event';
+import db from '../../../db';
+
+const BASE_EVENT = {
+  name: 'Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Venue',
+};
+
+let eventId: string;
+
+// `as any` below is needed because the rsvp service returns raw snake_case DB
+// rows (via `SELECT *`) while the declared types are camelCase — the same type
+// drift documented in eventService.test.ts.
+
+beforeEach(() => {
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+  eventId = createEvent(BASE_EVENT).id;
+});
+
+describe('rsvpToEventService', () => {
+  it('creates an RSVP with a 64-character hex token', () => {
+    const rsvp = rsvpToEventService({ id: uuidv4(), eventId, name: 'Alice', status: 'going' }) as any;
+    expect(rsvp.token).toHaveLength(64);
+    expect(rsvp.name).toBe('Alice');
+    expect(rsvp.status).toBe('going');
+  });
+
+  it('defaults guests to 0', () => {
+    const rsvp = rsvpToEventService({ id: uuidv4(), eventId, name: 'Bob', status: 'maybe' }) as any;
+    expect(rsvp.guests).toBe(0);
+  });
+
+  it('stores the provided guest count', () => {
+    const rsvp = rsvpToEventService({ id: uuidv4(), eventId, name: 'Carol', status: 'going', guests: 3 }) as any;
+    expect(rsvp.guests).toBe(3);
+  });
+
+  it('throws on a duplicate id rather than guarding client-supplied ids (BUG)', () => {
+    // BUG: rsvpToEventService trusts the caller-supplied `id` as the primary key,
+    // and the controller lets clients send their own id. A collision (accidental,
+    // or a malicious attempt to "claim" a specific UUID) hits the PK/UNIQUE
+    // constraint and surfaces as an unhandled 500 instead of a clean 4xx. The
+    // server should generate the id itself rather than trust the client.
+    const id = uuidv4();
+    rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' });
+    expect(() =>
+      rsvpToEventService({ id, eventId, name: 'Mallory', status: 'going' }),
+    ).toThrow();
+  });
+});
+
+describe('getRsvpByEventId', () => {
+  it('returns RSVPs for an event and orders by created_at ascending', () => {
+    // Insert with explicit timestamps to guarantee ordering
+    const now = new Date();
+    const idA = uuidv4();
+    const idB = uuidv4();
+    db.prepare(
+      `INSERT INTO rsvp (id, event_id, name, status, guests, created_at, updated_at, token) VALUES (?, ?, 'Alice', 'going', 0, ?, ?, 'tokA')`,
+    ).run(idA, eventId, new Date(now.getTime() - 1000).toISOString(), new Date(now.getTime() - 1000).toISOString());
+    db.prepare(
+      `INSERT INTO rsvp (id, event_id, name, status, guests, created_at, updated_at, token) VALUES (?, ?, 'Bob', 'maybe', 0, ?, ?, 'tokB')`,
+    ).run(idB, eventId, now.toISOString(), now.toISOString());
+    const rsvps = getRsvpByEventId(eventId) as any[];
+    expect(rsvps).toHaveLength(2);
+    expect(rsvps[0].name).toBe('Alice');
+    expect(rsvps[1].name).toBe('Bob');
+  });
+
+  it('does not expose the token in results', () => {
+    rsvpToEventService({ id: uuidv4(), eventId, name: 'Alice', status: 'going' });
+    const rsvps = getRsvpByEventId(eventId) as any[];
+    expect(rsvps[0]).not.toHaveProperty('token');
+  });
+
+  it('returns an empty array for an event with no RSVPs', () => {
+    expect(getRsvpByEventId(eventId)).toEqual([]);
+  });
+});
+
+describe('deleteRsvpById', () => {
+  it('deletes an RSVP and reports 1 change', () => {
+    const id = uuidv4();
+    rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' });
+    const result = deleteRsvpById(id);
+    expect(result.changes).toBe(1);
+    expect(getRsvpByEventId(eventId)).toHaveLength(0);
+  });
+
+  it('reports 0 changes for an unknown id', () => {
+    expect(deleteRsvpById('ghost').changes).toBe(0);
+  });
+});
+
+describe('updateRsvpByToken', () => {
+  it('updates name, status, and guests when the token matches', () => {
+    const id = uuidv4();
+    const rsvp = rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' }) as any;
+    const updated = updateRsvpByToken({
+      eventId,
+      rsvpId: id,
+      token: rsvp.token,
+      name: 'Alice B',
+      status: 'maybe',
+      guests: 2,
+    }) as any;
+    expect(updated.name).toBe('Alice B');
+    expect(updated.status).toBe('maybe');
+    expect(updated.guests).toBe(2);
+  });
+
+  it('leaks the secret token in its return value (BUG: token disclosure)', () => {
+    // BUG: updateRsvpByToken does `SELECT *`, so the per-RSVP secret edit token is
+    // included in the returned object and serialized straight back to the client
+    // by the controller. That token is a capability — anyone holding it can edit
+    // or delete the RSVP — so it must never appear in a response. The query should
+    // select explicit columns (as getRsvpByEventId already does). Until that is
+    // fixed, this test pins the leak so the eventual fix is a visible change.
+    const id = uuidv4();
+    const rsvp = rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' }) as any;
+    const updated = updateRsvpByToken({
+      eventId,
+      rsvpId: id,
+      token: rsvp.token,
+      name: 'Alice B',
+      status: 'maybe',
+      guests: 0,
+    }) as any;
+    expect(updated).toHaveProperty('token');
+  });
+
+  it('returns null when the token is wrong', () => {
+    const id = uuidv4();
+    rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' });
+    expect(
+      updateRsvpByToken({ eventId, rsvpId: id, token: 'wrongtoken', name: 'X', status: 'going', guests: 0 }),
+    ).toBeNull();
+  });
+
+  it('returns null when the rsvpId does not exist', () => {
+    expect(
+      updateRsvpByToken({ eventId, rsvpId: 'ghost', token: 'any', name: 'X', status: 'going', guests: 0 }),
+    ).toBeNull();
+  });
+
+  it('returns null when the eventId does not match', () => {
+    const id = uuidv4();
+    const rsvp = rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' }) as any;
+    const otherId = createEvent(BASE_EVENT).id;
+    expect(
+      updateRsvpByToken({ eventId: otherId, rsvpId: id, token: rsvp.token, name: 'X', status: 'going', guests: 0 }),
+    ).toBeNull();
+  });
+});
+
+describe('getMyRsvpsService', () => {
+  it('returns event+status pairs for matching rsvpId/eventId pairs', async () => {
+    const id = uuidv4();
+    rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' });
+    const results = (await getMyRsvpsService([{ rsvpId: id, eventId }])) as any[];
+    expect(results).toHaveLength(1);
+    expect(results[0].yourStatus).toBe('going');
+    expect(results[0].event.id).toBe(eventId);
+  });
+
+  it('includes attendeeName from the rsvp record', async () => {
+    const id = uuidv4();
+    rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' });
+    const results = (await getMyRsvpsService([{ rsvpId: id, eventId }])) as any[];
+    expect(results[0].attendeeName).toBe('Alice');
+  });
+
+  it('returns correct attendeeNames for multiple RSVPs on the same event', async () => {
+    const idA = uuidv4();
+    const idB = uuidv4();
+    rsvpToEventService({ id: idA, eventId, name: 'Alice', status: 'going' });
+    rsvpToEventService({ id: idB, eventId, name: 'Bob', status: 'maybe' });
+    const results = (await getMyRsvpsService([
+      { rsvpId: idA, eventId },
+      { rsvpId: idB, eventId },
+    ])) as any[];
+    expect(results).toHaveLength(2);
+    const names = results.map((r: any) => r.attendeeName).sort();
+    expect(names).toEqual(['Alice', 'Bob']);
+  });
+
+  it('returns empty array for empty input', async () => {
+    expect(await getMyRsvpsService([])).toEqual([]);
+  });
+
+  it('ignores pairs that do not exist', async () => {
+    const results = await getMyRsvpsService([{ rsvpId: 'ghost', eventId: 'ghost' }]);
+    expect(results).toHaveLength(0);
+  });
+});
+
+describe('foreign key cascade', () => {
+  it('cascade-deletes an event\'s RSVPs when the event is deleted', () => {
+    // The schema declares `FOREIGN KEY(event_id) ... ON DELETE CASCADE`, and
+    // better-sqlite3 enables foreign key enforcement by default (verified:
+    // `PRAGMA foreign_keys` is 1 on this connection), so deleting an event also
+    // removes its RSVPs rather than leaving orphaned rows. This guards against a
+    // future regression where the pragma gets turned off.
+    const id = uuidv4();
+    rsvpToEventService({ id, eventId, name: 'Alice', status: 'going' });
+    deleteEvent(eventId);
+    const orphan = db.prepare('SELECT id FROM rsvp WHERE id = ?').get(id);
+    expect(orphan).toBeFalsy();
+  });
+});

--- a/server/src/__tests__/unit/validators/isValidStatus.test.ts
+++ b/server/src/__tests__/unit/validators/isValidStatus.test.ts
@@ -1,0 +1,22 @@
+import { describe, expect, it } from 'vitest';
+import { isValidStatus } from '../../../validators/isValidStatus';
+
+describe('isValidStatus', () => {
+  it.each(['going', 'not_going', 'maybe'])('accepts "%s"', (status) => {
+    expect(isValidStatus(status)).toBe(true);
+  });
+
+  it.each(['', 'yes', 'no', 'GOING', 'going ', 'Going'])(
+    'rejects "%s"',
+    (status) => {
+      expect(isValidStatus(status)).toBe(false);
+    },
+  );
+
+  it.each([null, undefined, 123])(
+    'returns false for %s without throwing',
+    (value) => {
+      expect(isValidStatus(value as any)).toBe(false);
+    },
+  );
+});

--- a/server/src/config/index.ts
+++ b/server/src/config/index.ts
@@ -1,6 +1,12 @@
 import dotenv from 'dotenv';
 
-dotenv.config();
+// Load variables from .env for local dev (and as a no-op fallback in the
+// container, where the runtime already injects them). We deliberately skip this
+// under test: the test runner injects its own env (see vitest.config.ts), and
+// loading .env there could pull real/prod values into the test process.
+if (process.env.NODE_ENV !== 'test') {
+  dotenv.config();
+}
 
 const config = {
   NODE_ENV: process.env.NODE_ENV,

--- a/server/tsconfig.json
+++ b/server/tsconfig.json
@@ -7,5 +7,6 @@
     "strict": true,
     "esModuleInterop": true
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*"],
+  "exclude": ["src/__tests__/**/*", "node_modules", "dist"]
 }

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -1,0 +1,15 @@
+import { defineConfig } from 'vitest/config';
+
+export default defineConfig({
+  test: {
+    environment: 'node',
+    setupFiles: ['./src/__tests__/setup.ts'],
+    env: {
+      // NODE_ENV=test makes config/index.ts skip dotenv so tests never read .env
+      NODE_ENV: 'test',
+      SQLITE_DB_PATH: ':memory:',
+      ADMIN_USER: 'testadmin',
+      ADMIN_PASSWORD: 'testpass',
+    },
+  },
+});

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -5,12 +5,82 @@ __metadata:
   version: 8
   cacheKey: 10c0
 
+"@babel/helper-string-parser@npm:^7.27.1":
+  version: 7.27.1
+  resolution: "@babel/helper-string-parser@npm:7.27.1"
+  checksum: 10c0/8bda3448e07b5583727c103560bcf9c4c24b3c1051a4c516d4050ef69df37bb9a4734a585fe12725b8c2763de0a265aa1e909b485a4e3270b7cfd3e4dbe4b602
+  languageName: node
+  linkType: hard
+
+"@babel/helper-validator-identifier@npm:^7.28.5":
+  version: 7.28.5
+  resolution: "@babel/helper-validator-identifier@npm:7.28.5"
+  checksum: 10c0/42aaebed91f739a41f3d80b72752d1f95fd7c72394e8e4bd7cdd88817e0774d80a432451bcba17c2c642c257c483bf1d409dd4548883429ea9493a3bc4ab0847
+  languageName: node
+  linkType: hard
+
+"@babel/parser@npm:^7.29.3":
+  version: 7.29.3
+  resolution: "@babel/parser@npm:7.29.3"
+  dependencies:
+    "@babel/types": "npm:^7.29.0"
+  bin:
+    parser: ./bin/babel-parser.js
+  checksum: 10c0/f06920c819550c0db689e4c5b626bf55ba3cebf80ebe9ccfa434e134036cf3de50951fe759f74abb2dae381989239860bde46d4600328578ad1f7114c3711a6d
+  languageName: node
+  linkType: hard
+
+"@babel/types@npm:^7.29.0":
+  version: 7.29.0
+  resolution: "@babel/types@npm:7.29.0"
+  dependencies:
+    "@babel/helper-string-parser": "npm:^7.27.1"
+    "@babel/helper-validator-identifier": "npm:^7.28.5"
+  checksum: 10c0/23cc3466e83bcbfab8b9bd0edaafdb5d4efdb88b82b3be6728bbade5ba2f0996f84f63b1c5f7a8c0d67efded28300898a5f930b171bb40b311bca2029c4e9b4f
+  languageName: node
+  linkType: hard
+
+"@bcoe/v8-coverage@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "@bcoe/v8-coverage@npm:1.0.2"
+  checksum: 10c0/1eb1dc93cc17fb7abdcef21a6e7b867d6aa99a7ec88ec8207402b23d9083ab22a8011213f04b2cf26d535f1d22dc26139b7929e6c2134c254bd1e14ba5e678c3
+  languageName: node
+  linkType: hard
+
 "@cspotcode/source-map-support@npm:^0.8.0":
   version: 0.8.1
   resolution: "@cspotcode/source-map-support@npm:0.8.1"
   dependencies:
     "@jridgewell/trace-mapping": "npm:0.3.9"
   checksum: 10c0/05c5368c13b662ee4c122c7bfbe5dc0b613416672a829f3e78bc49a357a197e0218d6e74e7c66cfcd04e15a179acab080bd3c69658c9fbefd0e1ccd950a07fc6
+  languageName: node
+  linkType: hard
+
+"@emnapi/core@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/core@npm:1.10.0"
+  dependencies:
+    "@emnapi/wasi-threads": "npm:1.2.1"
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/f51d08227857b60632de7714d708124f0e100a1462dde6df8221760939aa3204a73193830371830fac0716f3ccd2129f2cac1b17cd7d7958bc4da9018a296edb
+  languageName: node
+  linkType: hard
+
+"@emnapi/runtime@npm:1.10.0":
+  version: 1.10.0
+  resolution: "@emnapi/runtime@npm:1.10.0"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/953f14991d1aefb92ee6f8eb27dea725e484791a53a0cb5f47d9e0087b9a2c929ff2e92adf95af15d6ad456db6300c6b761ebf72b50a875b874a83520b3ba093
+  languageName: node
+  linkType: hard
+
+"@emnapi/wasi-threads@npm:1.2.1":
+  version: 1.2.1
+  resolution: "@emnapi/wasi-threads@npm:1.2.1"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/32fcfa81ab396533b2ec1f4082b1ff779a05d9c836bbbd3f4398405b0e6814c0d9503b7993130e37bc6941dbc1ded49f55e9700ae9ca4e803bab2b5bc5deb331
   languageName: node
   linkType: hard
 
@@ -37,14 +107,14 @@ __metadata:
   languageName: node
   linkType: hard
 
-"@jridgewell/resolve-uri@npm:^3.0.3":
+"@jridgewell/resolve-uri@npm:^3.0.3, @jridgewell/resolve-uri@npm:^3.1.0":
   version: 3.1.2
   resolution: "@jridgewell/resolve-uri@npm:3.1.2"
   checksum: 10c0/d502e6fb516b35032331406d4e962c21fe77cdf1cbdb49c6142bcbd9e30507094b18972778a6e27cbad756209cfe34b1a27729e6fa08a2eb92b33943f680cf1e
   languageName: node
   linkType: hard
 
-"@jridgewell/sourcemap-codec@npm:^1.4.10":
+"@jridgewell/sourcemap-codec@npm:^1.4.10, @jridgewell/sourcemap-codec@npm:^1.4.14, @jridgewell/sourcemap-codec@npm:^1.5.5":
   version: 1.5.5
   resolution: "@jridgewell/sourcemap-codec@npm:1.5.5"
   checksum: 10c0/f9e538f302b63c0ebc06eecb1dd9918dd4289ed36147a0ddce35d6ea4d7ebbda243cda7b2213b6a5e1d8087a298d5cf630fb2bd39329cdecb82017023f6081a0
@@ -58,6 +128,28 @@ __metadata:
     "@jridgewell/resolve-uri": "npm:^3.0.3"
     "@jridgewell/sourcemap-codec": "npm:^1.4.10"
   checksum: 10c0/fa425b606d7c7ee5bfa6a31a7b050dd5814b4082f318e0e4190f991902181b4330f43f4805db1dd4f2433fd0ed9cc7a7b9c2683f1deeab1df1b0a98b1e24055b
+  languageName: node
+  linkType: hard
+
+"@jridgewell/trace-mapping@npm:^0.3.31":
+  version: 0.3.31
+  resolution: "@jridgewell/trace-mapping@npm:0.3.31"
+  dependencies:
+    "@jridgewell/resolve-uri": "npm:^3.1.0"
+    "@jridgewell/sourcemap-codec": "npm:^1.4.14"
+  checksum: 10c0/4b30ec8cd56c5fd9a661f088230af01e0c1a3888d11ffb6b47639700f71225be21d1f7e168048d6d4f9449207b978a235c07c8f15c07705685d16dc06280e9d9
+  languageName: node
+  linkType: hard
+
+"@napi-rs/wasm-runtime@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@napi-rs/wasm-runtime@npm:1.1.4"
+  dependencies:
+    "@tybys/wasm-util": "npm:^0.10.1"
+  peerDependencies:
+    "@emnapi/core": ^1.7.1
+    "@emnapi/runtime": ^1.7.1
+  checksum: 10c0/2e88e1955258949ccf2d18c79975821ad38071b465ef126a5e14110977b97868867b016c1ad046e963cccc42c0bd9db6c8ff5fd1ebb61b87bb3487f339041658
   languageName: node
   linkType: hard
 
@@ -83,10 +175,140 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@oxc-project/types@npm:=0.130.0":
+  version: 0.130.0
+  resolution: "@oxc-project/types@npm:0.130.0"
+  checksum: 10c0/7ec8c03407b0bcb235b930c62859e6efcb3fe5cbaa5db98770d760df5c3e6b3e28a0ad22c2e35d1addede8065b40000c3822c5235dde2959af226639eb870000
+  languageName: node
+  linkType: hard
+
 "@pkgjs/parseargs@npm:^0.11.0":
   version: 0.11.0
   resolution: "@pkgjs/parseargs@npm:0.11.0"
   checksum: 10c0/5bd7576bb1b38a47a7fc7b51ac9f38748e772beebc56200450c4a817d712232b8f1d3ef70532c80840243c657d491cf6a6be1e3a214cff907645819fdc34aadd
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-android-arm64@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-android-arm64@npm:1.0.1"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-arm64@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-darwin-arm64@npm:1.0.1"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-darwin-x64@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-darwin-x64@npm:1.0.1"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-freebsd-x64@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-freebsd-x64@npm:1.0.1"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm-gnueabihf@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-arm-gnueabihf@npm:1.0.1"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-gnu@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-arm64-gnu@npm:1.0.1"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-arm64-musl@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-arm64-musl@npm:1.0.1"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-ppc64-gnu@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-ppc64-gnu@npm:1.0.1"
+  conditions: os=linux & cpu=ppc64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-s390x-gnu@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-s390x-gnu@npm:1.0.1"
+  conditions: os=linux & cpu=s390x & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-gnu@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-x64-gnu@npm:1.0.1"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-linux-x64-musl@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-linux-x64-musl@npm:1.0.1"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-openharmony-arm64@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-openharmony-arm64@npm:1.0.1"
+  conditions: os=openharmony & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-wasm32-wasi@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-wasm32-wasi@npm:1.0.1"
+  dependencies:
+    "@emnapi/core": "npm:1.10.0"
+    "@emnapi/runtime": "npm:1.10.0"
+    "@napi-rs/wasm-runtime": "npm:^1.1.4"
+  conditions: cpu=wasm32
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-arm64-msvc@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-win32-arm64-msvc@npm:1.0.1"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"@rolldown/binding-win32-x64-msvc@npm:1.0.1":
+  version: 1.0.1
+  resolution: "@rolldown/binding-win32-x64-msvc@npm:1.0.1"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"@rolldown/pluginutils@npm:^1.0.0":
+  version: 1.0.1
+  resolution: "@rolldown/pluginutils@npm:1.0.1"
+  checksum: 10c0/99d9b06d90196823e4d8c841f258db7a16e5dbba5824a2962b05d907b79f1ba929d56f22dd744fd530936e568c865ee56a719dc31e57e13bc0a8eb4764a8d8dd
+  languageName: node
+  linkType: hard
+
+"@standard-schema/spec@npm:^1.1.0":
+  version: 1.1.0
+  resolution: "@standard-schema/spec@npm:1.1.0"
+  checksum: 10c0/d90f55acde4b2deb983529c87e8025fa693de1a5e8b49ecc6eb84d1fd96328add0e03d7d551442156c7432fd78165b2c26ff561b970a9a881f046abb78d6a526
   languageName: node
   linkType: hard
 
@@ -118,6 +340,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@tybys/wasm-util@npm:^0.10.1":
+  version: 0.10.2
+  resolution: "@tybys/wasm-util@npm:0.10.2"
+  dependencies:
+    tslib: "npm:^2.4.0"
+  checksum: 10c0/26165bcd1fd7269f42d7fbe3de318f854a8968de8397e89fc9a423bb3e2da35a52150f382e6323b3367595beb16d9800a6f35971a5599daf76da1742ec3afc25
+  languageName: node
+  linkType: hard
+
 "@types/better-sqlite3@npm:^7.6.13":
   version: 7.6.13
   resolution: "@types/better-sqlite3@npm:7.6.13"
@@ -134,6 +365,16 @@ __metadata:
     "@types/connect": "npm:*"
     "@types/node": "npm:*"
   checksum: 10c0/542da05c924dce58ee23f50a8b981fee36921850c82222e384931fda3e106f750f7880c47be665217d72dbe445129049db6eb1f44e7a06b09d62af8f3cca8ea7
+  languageName: node
+  linkType: hard
+
+"@types/chai@npm:^5.2.2":
+  version: 5.2.3
+  resolution: "@types/chai@npm:5.2.3"
+  dependencies:
+    "@types/deep-eql": "npm:*"
+    assertion-error: "npm:^2.0.1"
+  checksum: 10c0/e0ef1de3b6f8045a5e473e867c8565788c444271409d155588504840ad1a53611011f85072188c2833941189400228c1745d78323dac13fcede9c2b28bacfb2f
   languageName: node
   linkType: hard
 
@@ -155,12 +396,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/deep-eql@npm:*":
+  version: 4.0.2
+  resolution: "@types/deep-eql@npm:4.0.2"
+  checksum: 10c0/bf3f811843117900d7084b9d0c852da9a044d12eb40e6de73b552598a6843c21291a8a381b0532644574beecd5e3491c5ff3a0365ab86b15d59862c025384844
+  languageName: node
+  linkType: hard
+
 "@types/dotenv@npm:^8.2.3":
   version: 8.2.3
   resolution: "@types/dotenv@npm:8.2.3"
   dependencies:
     dotenv: "npm:*"
   checksum: 10c0/af9178da617959cddc8259aaa3f16c474523ead469f4a03490de2f2d1cafc8615c5d0d1ed3fad837096218126421c38cd46b4065548bb5aee3cc002c518b69f7
+  languageName: node
+  linkType: hard
+
+"@types/estree@npm:^1.0.0":
+  version: 1.0.9
+  resolution: "@types/estree@npm:1.0.9"
+  checksum: 10c0/3ad3286ca2988cd550dafb8f2ad599c8474868e954fa601a36655bdfefd8039f7c714b8c1c7f2ae219ffbd58bd4660e66fa7479a0120fc02d4777057d4865387
   languageName: node
   linkType: hard
 
@@ -245,6 +500,112 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@vitest/coverage-v8@npm:^4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/coverage-v8@npm:4.1.6"
+  dependencies:
+    "@bcoe/v8-coverage": "npm:^1.0.2"
+    "@vitest/utils": "npm:4.1.6"
+    ast-v8-to-istanbul: "npm:^1.0.0"
+    istanbul-lib-coverage: "npm:^3.2.2"
+    istanbul-lib-report: "npm:^3.0.1"
+    istanbul-reports: "npm:^3.2.0"
+    magicast: "npm:^0.5.2"
+    obug: "npm:^2.1.1"
+    std-env: "npm:^4.0.0-rc.1"
+    tinyrainbow: "npm:^3.1.0"
+  peerDependencies:
+    "@vitest/browser": 4.1.6
+    vitest: 4.1.6
+  peerDependenciesMeta:
+    "@vitest/browser":
+      optional: true
+  checksum: 10c0/5cc45784200a13ccab166c5d2ed0a4026ab0e28c395a654f046d91ff344a02d38db77b1022d7aa6d07973966c64844a6b62756c88c33609529535c12cc8b1af4
+  languageName: node
+  linkType: hard
+
+"@vitest/expect@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/expect@npm:4.1.6"
+  dependencies:
+    "@standard-schema/spec": "npm:^1.1.0"
+    "@types/chai": "npm:^5.2.2"
+    "@vitest/spy": "npm:4.1.6"
+    "@vitest/utils": "npm:4.1.6"
+    chai: "npm:^6.2.2"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/a6767bdf586c82f64674998bf74987e99aa106ac5d0b5c4c2c1d3924e145b34fd80e138c65568a8fc2544aa71c85b1272f9607fe5ef6a7060ece1c232db46655
+  languageName: node
+  linkType: hard
+
+"@vitest/mocker@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/mocker@npm:4.1.6"
+  dependencies:
+    "@vitest/spy": "npm:4.1.6"
+    estree-walker: "npm:^3.0.3"
+    magic-string: "npm:^0.30.21"
+  peerDependencies:
+    msw: ^2.4.9
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    msw:
+      optional: true
+    vite:
+      optional: true
+  checksum: 10c0/d9f3236940e160467edb7a2552fa014451347c4f08c13d26220fcfe7e12b385fd4975c6a81a6b174117650772cf3c45195b3a1838f8ee28fc8e6c37e07b99b2d
+  languageName: node
+  linkType: hard
+
+"@vitest/pretty-format@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/pretty-format@npm:4.1.6"
+  dependencies:
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/f818a6abff9b7cf642edc2d0fe84d4f124911696bc7591f2af9ab6d88685b72133a1e9f87499e9b4dc2314dff85403ea66c64f7b408b2eb39f9880c6d3517ca0
+  languageName: node
+  linkType: hard
+
+"@vitest/runner@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/runner@npm:4.1.6"
+  dependencies:
+    "@vitest/utils": "npm:4.1.6"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/8047051d730de66b7cde8e6803ea718eaa8342ffbe55ff3d787fe7085a2b824a979689782d5303e464411fe67b556384b0c5af337e3e335cf140bf7adf5f6aa0
+  languageName: node
+  linkType: hard
+
+"@vitest/snapshot@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/snapshot@npm:4.1.6"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.6"
+    "@vitest/utils": "npm:4.1.6"
+    magic-string: "npm:^0.30.21"
+    pathe: "npm:^2.0.3"
+  checksum: 10c0/596d7cd2fe12b57516e983e550d238c324a3cefaac826e557b0903cfbb11f6ff79582bf2df6dc3163cf604c305ffe3840e47f03a95b8fb8d7bf6200462e8cfea
+  languageName: node
+  linkType: hard
+
+"@vitest/spy@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/spy@npm:4.1.6"
+  checksum: 10c0/908034532fb10888f759603194b11058bdabdf9bb86ef7839feec98f809e4802cf8d74c279c521ef2df12fa9ab97d0aec7c886e1e6910c5c9dfb10ba00913d91
+  languageName: node
+  linkType: hard
+
+"@vitest/utils@npm:4.1.6":
+  version: 4.1.6
+  resolution: "@vitest/utils@npm:4.1.6"
+  dependencies:
+    "@vitest/pretty-format": "npm:4.1.6"
+    convert-source-map: "npm:^2.0.0"
+    tinyrainbow: "npm:^3.1.0"
+  checksum: 10c0/36437888088a1aae8565e62b9f145de9fb1599725574924477c655c7617ad677b575ac0eb3f2b3288854ed1aafff914a0417dffbb7f5244c821f157119701227
+  languageName: node
+  linkType: hard
+
 "abbrev@npm:^3.0.0":
   version: 3.0.1
   resolution: "abbrev@npm:3.0.1"
@@ -321,6 +682,24 @@ __metadata:
   version: 4.1.3
   resolution: "arg@npm:4.1.3"
   checksum: 10c0/070ff801a9d236a6caa647507bdcc7034530604844d64408149a26b9e87c2f97650055c0f049abd1efc024b334635c01f29e0b632b371ac3f26130f4cf65997a
+  languageName: node
+  linkType: hard
+
+"assertion-error@npm:^2.0.1":
+  version: 2.0.1
+  resolution: "assertion-error@npm:2.0.1"
+  checksum: 10c0/bbbcb117ac6480138f8c93cf7f535614282dea9dc828f540cdece85e3c665e8f78958b96afac52f29ff883c72638e6a87d469ecc9fe5bc902df03ed24a55dba8
+  languageName: node
+  linkType: hard
+
+"ast-v8-to-istanbul@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "ast-v8-to-istanbul@npm:1.0.0"
+  dependencies:
+    "@jridgewell/trace-mapping": "npm:^0.3.31"
+    estree-walker: "npm:^3.0.3"
+    js-tokens: "npm:^10.0.0"
+  checksum: 10c0/35e57b754ba63287358094d4f7ae8de2de27286fb4e76a1fbf28b2e67e3b670b59c3f511882473d0fd2cdbaa260062e3cd4f216b724c70032e2b09e5cebbd618
   languageName: node
   linkType: hard
 
@@ -452,6 +831,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"chai@npm:^6.2.2":
+  version: 6.2.2
+  resolution: "chai@npm:6.2.2"
+  checksum: 10c0/e6c69e5f0c11dffe6ea13d0290936ebb68fcc1ad688b8e952e131df6a6d5797d5e860bc55cef1aca2e950c3e1f96daf79e9d5a70fb7dbaab4e46355e2635ed53
+  languageName: node
+  linkType: hard
+
 "chownr@npm:^1.1.1":
   version: 1.1.4
   resolution: "chownr@npm:1.1.4"
@@ -495,6 +881,13 @@ __metadata:
   version: 1.0.5
   resolution: "content-type@npm:1.0.5"
   checksum: 10c0/b76ebed15c000aee4678c3707e0860cb6abd4e680a598c0a26e17f0bfae723ec9cc2802f0ff1bc6e4d80603719010431d2231018373d4dde10f9ccff9dadf5af
+  languageName: node
+  linkType: hard
+
+"convert-source-map@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "convert-source-map@npm:2.0.0"
+  checksum: 10c0/8f2f7a27a1a011cc6cc88cc4da2d7d0cfa5ee0369508baae3d98c260bb3ac520691464e5bbe4ae7cdf09860c1d69ecc6f70c63c6e7c7f7e3f18ec08484dc7d9b
   languageName: node
   linkType: hard
 
@@ -579,6 +972,13 @@ __metadata:
   version: 2.0.4
   resolution: "detect-libc@npm:2.0.4"
   checksum: 10c0/c15541f836eba4b1f521e4eecc28eefefdbc10a94d3b8cb4c507689f332cc111babb95deda66f2de050b22122113189986d5190be97d51b5a2b23b938415e67c
+  languageName: node
+  linkType: hard
+
+"detect-libc@npm:^2.0.3":
+  version: 2.1.2
+  resolution: "detect-libc@npm:2.1.2"
+  checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
   languageName: node
   linkType: hard
 
@@ -688,6 +1088,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-module-lexer@npm:^2.0.0":
+  version: 2.1.0
+  resolution: "es-module-lexer@npm:2.1.0"
+  checksum: 10c0/93bcf2454fa72d67fe3ccd0abef8ce7933f5840a319513418a643dd8e9c6aa8f49709cecfae02ded722805dd327232d30723a807cc52e6809d6ac697c62c29fb
+  languageName: node
+  linkType: hard
+
 "es-object-atoms@npm:^1.0.0, es-object-atoms@npm:^1.1.1":
   version: 1.1.1
   resolution: "es-object-atoms@npm:1.1.1"
@@ -704,6 +1111,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"estree-walker@npm:^3.0.3":
+  version: 3.0.3
+  resolution: "estree-walker@npm:3.0.3"
+  dependencies:
+    "@types/estree": "npm:^1.0.0"
+  checksum: 10c0/c12e3c2b2642d2bcae7d5aa495c60fa2f299160946535763969a1c83fc74518ffa9c2cd3a8b69ac56aea547df6a8aac25f729a342992ef0bbac5f1c73e78995d
+  languageName: node
+  linkType: hard
+
 "etag@npm:^1.8.1":
   version: 1.8.1
   resolution: "etag@npm:1.8.1"
@@ -715,6 +1131,13 @@ __metadata:
   version: 2.0.3
   resolution: "expand-template@npm:2.0.3"
   checksum: 10c0/1c9e7afe9acadf9d373301d27f6a47b34e89b3391b1ef38b7471d381812537ef2457e620ae7f819d2642ce9c43b189b3583813ec395e2938319abe356a9b2f51
+  languageName: node
+  linkType: hard
+
+"expect-type@npm:^1.3.0":
+  version: 1.3.0
+  resolution: "expect-type@npm:1.3.0"
+  checksum: 10c0/8412b3fe4f392c420ab41dae220b09700e4e47c639a29ba7ba2e83cc6cffd2b4926f7ac9e47d7e277e8f4f02acda76fd6931cb81fd2b382fa9477ef9ada953fd
   languageName: node
   linkType: hard
 
@@ -771,7 +1194,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"fdir@npm:^6.4.4":
+"fdir@npm:^6.4.4, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
   peerDependencies:
@@ -841,6 +1264,25 @@ __metadata:
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/63e80da2ff9b621e2cb1596abcb9207f1cf82b968b116ccd7b959e3323144cce7fb141462200971c38bbf2ecca51695069db45265705bed09a7cd93ae5b89f94
+  languageName: node
+  linkType: hard
+
+"fsevents@npm:~2.3.3":
+  version: 2.3.3
+  resolution: "fsevents@npm:2.3.3"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A~2.3.3#optional!builtin<compat/fsevents>":
+  version: 2.3.3
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.3#optional!builtin<compat/fsevents>::version=2.3.3&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
+  conditions: os=darwin
   languageName: node
   linkType: hard
 
@@ -916,6 +1358,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"has-flag@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "has-flag@npm:4.0.0"
+  checksum: 10c0/2e789c61b7888d66993e14e8331449e525ef42aac53c627cc53d1c3334e768bcb6abdc4f5f0de1478a25beec6f0bd62c7549058b7ac53e924040d4f301f02fd1
+  languageName: node
+  linkType: hard
+
 "has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
@@ -929,6 +1378,13 @@ __metadata:
   dependencies:
     function-bind: "npm:^1.1.2"
   checksum: 10c0/3769d434703b8ac66b209a4cca0737519925bbdb61dd887f93a16372b14694c63ff4e797686d87c90f08168e81082248b9b028bad60d4da9e0d1148766f56eb9
+  languageName: node
+  linkType: hard
+
+"html-escaper@npm:^2.0.0":
+  version: 2.0.2
+  resolution: "html-escaper@npm:2.0.2"
+  checksum: 10c0/208e8a12de1a6569edbb14544f4567e6ce8ecc30b9394fcaa4e7bb1e60c12a7c9a1ed27e31290817157e8626f3a4f29e76c8747030822eb84a6abb15c255f0a0
   languageName: node
   linkType: hard
 
@@ -1051,6 +1507,34 @@ __metadata:
   languageName: node
   linkType: hard
 
+"istanbul-lib-coverage@npm:^3.0.0, istanbul-lib-coverage@npm:^3.2.2":
+  version: 3.2.2
+  resolution: "istanbul-lib-coverage@npm:3.2.2"
+  checksum: 10c0/6c7ff2106769e5f592ded1fb418f9f73b4411fd5a084387a5410538332b6567cd1763ff6b6cadca9b9eb2c443cce2f7ea7d7f1b8d315f9ce58539793b1e0922b
+  languageName: node
+  linkType: hard
+
+"istanbul-lib-report@npm:^3.0.0, istanbul-lib-report@npm:^3.0.1":
+  version: 3.0.1
+  resolution: "istanbul-lib-report@npm:3.0.1"
+  dependencies:
+    istanbul-lib-coverage: "npm:^3.0.0"
+    make-dir: "npm:^4.0.0"
+    supports-color: "npm:^7.1.0"
+  checksum: 10c0/84323afb14392de8b6a5714bd7e9af845cfbd56cfe71ed276cda2f5f1201aea673c7111901227ee33e68e4364e288d73861eb2ed48f6679d1e69a43b6d9b3ba7
+  languageName: node
+  linkType: hard
+
+"istanbul-reports@npm:^3.2.0":
+  version: 3.2.0
+  resolution: "istanbul-reports@npm:3.2.0"
+  dependencies:
+    html-escaper: "npm:^2.0.0"
+    istanbul-lib-report: "npm:^3.0.0"
+  checksum: 10c0/d596317cfd9c22e1394f22a8d8ba0303d2074fe2e971887b32d870e4b33f8464b10f8ccbe6847808f7db485f084eba09e6c2ed706b3a978e4b52f07085b8f9bc
+  languageName: node
+  linkType: hard
+
 "jackspeak@npm:^3.1.2":
   version: 3.4.3
   resolution: "jackspeak@npm:3.4.3"
@@ -1064,10 +1548,166 @@ __metadata:
   languageName: node
   linkType: hard
 
+"js-tokens@npm:^10.0.0":
+  version: 10.0.0
+  resolution: "js-tokens@npm:10.0.0"
+  checksum: 10c0/a93498747812ba3e0c8626f95f75ab29319f2a13613a0de9e610700405760931624433a0de59eb7c27ff8836e526768fb20783861b86ef89be96676f2c996b64
+  languageName: node
+  linkType: hard
+
+"lightningcss-android-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-android-arm64@npm:1.32.0"
+  conditions: os=android & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-arm64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-arm64@npm:1.32.0"
+  conditions: os=darwin & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-darwin-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-darwin-x64@npm:1.32.0"
+  conditions: os=darwin & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-freebsd-x64@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-freebsd-x64@npm:1.32.0"
+  conditions: os=freebsd & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm-gnueabihf@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm-gnueabihf@npm:1.32.0"
+  conditions: os=linux & cpu=arm
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-arm64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-arm64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=arm64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-gnu@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-gnu@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=glibc
+  languageName: node
+  linkType: hard
+
+"lightningcss-linux-x64-musl@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-linux-x64-musl@npm:1.32.0"
+  conditions: os=linux & cpu=x64 & libc=musl
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-arm64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-arm64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=arm64
+  languageName: node
+  linkType: hard
+
+"lightningcss-win32-x64-msvc@npm:1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss-win32-x64-msvc@npm:1.32.0"
+  conditions: os=win32 & cpu=x64
+  languageName: node
+  linkType: hard
+
+"lightningcss@npm:^1.32.0":
+  version: 1.32.0
+  resolution: "lightningcss@npm:1.32.0"
+  dependencies:
+    detect-libc: "npm:^2.0.3"
+    lightningcss-android-arm64: "npm:1.32.0"
+    lightningcss-darwin-arm64: "npm:1.32.0"
+    lightningcss-darwin-x64: "npm:1.32.0"
+    lightningcss-freebsd-x64: "npm:1.32.0"
+    lightningcss-linux-arm-gnueabihf: "npm:1.32.0"
+    lightningcss-linux-arm64-gnu: "npm:1.32.0"
+    lightningcss-linux-arm64-musl: "npm:1.32.0"
+    lightningcss-linux-x64-gnu: "npm:1.32.0"
+    lightningcss-linux-x64-musl: "npm:1.32.0"
+    lightningcss-win32-arm64-msvc: "npm:1.32.0"
+    lightningcss-win32-x64-msvc: "npm:1.32.0"
+  dependenciesMeta:
+    lightningcss-android-arm64:
+      optional: true
+    lightningcss-darwin-arm64:
+      optional: true
+    lightningcss-darwin-x64:
+      optional: true
+    lightningcss-freebsd-x64:
+      optional: true
+    lightningcss-linux-arm-gnueabihf:
+      optional: true
+    lightningcss-linux-arm64-gnu:
+      optional: true
+    lightningcss-linux-arm64-musl:
+      optional: true
+    lightningcss-linux-x64-gnu:
+      optional: true
+    lightningcss-linux-x64-musl:
+      optional: true
+    lightningcss-win32-arm64-msvc:
+      optional: true
+    lightningcss-win32-x64-msvc:
+      optional: true
+  checksum: 10c0/70945bd55097af46fc9fab7f5ed09cd5869d85940a2acab7ee06d0117004a1d68155708a2d462531cea2fc3c67aefc9333a7068c80b0b78dd404c16838809e03
+  languageName: node
+  linkType: hard
+
 "lru-cache@npm:^10.0.1, lru-cache@npm:^10.2.0":
   version: 10.4.3
   resolution: "lru-cache@npm:10.4.3"
   checksum: 10c0/ebd04fbca961e6c1d6c0af3799adcc966a1babe798f685bb84e6599266599cd95d94630b10262f5424539bc4640107e8a33aa28585374abf561d30d16f4b39fb
+  languageName: node
+  linkType: hard
+
+"magic-string@npm:^0.30.21":
+  version: 0.30.21
+  resolution: "magic-string@npm:0.30.21"
+  dependencies:
+    "@jridgewell/sourcemap-codec": "npm:^1.5.5"
+  checksum: 10c0/299378e38f9a270069fc62358522ddfb44e94244baa0d6a8980ab2a9b2490a1d03b236b447eee309e17eb3bddfa482c61259d47960eb018a904f0ded52780c4a
+  languageName: node
+  linkType: hard
+
+"magicast@npm:^0.5.2":
+  version: 0.5.3
+  resolution: "magicast@npm:0.5.3"
+  dependencies:
+    "@babel/parser": "npm:^7.29.3"
+    "@babel/types": "npm:^7.29.0"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/e288c027ae5f2a794a59148cb114f4b60f1d5c03090de6c60b4d187f12d1de9158779cd7c39cea391609f4f10cd7ea737929f25f7ce44f7a96ba96ec1a477e39
+  languageName: node
+  linkType: hard
+
+"make-dir@npm:^4.0.0":
+  version: 4.0.0
+  resolution: "make-dir@npm:4.0.0"
+  dependencies:
+    semver: "npm:^7.5.3"
+  checksum: 10c0/69b98a6c0b8e5c4fe9acb61608a9fbcfca1756d910f51e5dbe7a9e5cfb74fca9b8a0c8a0ffdf1294a740826c1ab4871d5bf3f62f72a3049e5eac6541ddffed68
   languageName: node
   linkType: hard
 
@@ -1256,6 +1896,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"nanoid@npm:^3.3.11":
+  version: 3.3.12
+  resolution: "nanoid@npm:3.3.12"
+  bin:
+    nanoid: bin/nanoid.cjs
+  checksum: 10c0/ba142b7b39e11e80c16dd74b0365d407880c87c1cf7e1480956981ae940ee36060fa5b6f092cd1e315184dd19244c657bd017d03327bd3c62247d691c5e8edfb
+  languageName: node
+  linkType: hard
+
 "napi-build-utils@npm:^2.0.0":
   version: 2.0.0
   resolution: "napi-build-utils@npm:2.0.0"
@@ -1324,6 +1973,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"obug@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "obug@npm:2.1.1"
+  checksum: 10c0/59dccd7de72a047e08f8649e94c1015ec72f94eefb6ddb57fb4812c4b425a813bc7e7cd30c9aca20db3c59abc3c85cc7a62bb656a968741d770f4e8e02bc2e78
+  languageName: node
+  linkType: hard
+
 "on-finished@npm:^2.4.1":
   version: 2.4.1
   resolution: "on-finished@npm:2.4.1"
@@ -1387,10 +2043,42 @@ __metadata:
   languageName: node
   linkType: hard
 
+"pathe@npm:^2.0.3":
+  version: 2.0.3
+  resolution: "pathe@npm:2.0.3"
+  checksum: 10c0/c118dc5a8b5c4166011b2b70608762e260085180bb9e33e80a50dcdb1e78c010b1624f4280c492c92b05fc276715a4c357d1f9edc570f8f1b3d90b6839ebaca1
+  languageName: node
+  linkType: hard
+
+"picocolors@npm:^1.1.1":
+  version: 1.1.1
+  resolution: "picocolors@npm:1.1.1"
+  checksum: 10c0/e2e3e8170ab9d7c7421969adaa7e1b31434f789afb9b3f115f6b96d91945041ac3ceb02e9ec6fe6510ff036bcc0bf91e69a1772edc0b707e12b19c0f2d6bcf58
+  languageName: node
+  linkType: hard
+
 "picomatch@npm:^4.0.2":
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
+"picomatch@npm:^4.0.3, picomatch@npm:^4.0.4":
+  version: 4.0.4
+  resolution: "picomatch@npm:4.0.4"
+  checksum: 10c0/e2c6023372cc7b5764719a5ffb9da0f8e781212fa7ca4bd0562db929df8e117460f00dff3cb7509dacfc06b86de924b247f504d0ce1806a37fac4633081466b0
+  languageName: node
+  linkType: hard
+
+"postcss@npm:^8.5.14":
+  version: 8.5.14
+  resolution: "postcss@npm:8.5.14"
+  dependencies:
+    nanoid: "npm:^3.3.11"
+    picocolors: "npm:^1.1.1"
+    source-map-js: "npm:^1.2.1"
+  checksum: 10c0/48138207cf5ef5581be1bfe2cb65ccfe0ac75e43888ba045afc8ed6043d7b56aeb3b9a9fe5b353ff554be943cd0cc15d826ccb991525159175971e5ee8ab0237
   languageName: node
   linkType: hard
 
@@ -1513,6 +2201,64 @@ __metadata:
   languageName: node
   linkType: hard
 
+"rolldown@npm:1.0.1":
+  version: 1.0.1
+  resolution: "rolldown@npm:1.0.1"
+  dependencies:
+    "@oxc-project/types": "npm:=0.130.0"
+    "@rolldown/binding-android-arm64": "npm:1.0.1"
+    "@rolldown/binding-darwin-arm64": "npm:1.0.1"
+    "@rolldown/binding-darwin-x64": "npm:1.0.1"
+    "@rolldown/binding-freebsd-x64": "npm:1.0.1"
+    "@rolldown/binding-linux-arm-gnueabihf": "npm:1.0.1"
+    "@rolldown/binding-linux-arm64-gnu": "npm:1.0.1"
+    "@rolldown/binding-linux-arm64-musl": "npm:1.0.1"
+    "@rolldown/binding-linux-ppc64-gnu": "npm:1.0.1"
+    "@rolldown/binding-linux-s390x-gnu": "npm:1.0.1"
+    "@rolldown/binding-linux-x64-gnu": "npm:1.0.1"
+    "@rolldown/binding-linux-x64-musl": "npm:1.0.1"
+    "@rolldown/binding-openharmony-arm64": "npm:1.0.1"
+    "@rolldown/binding-wasm32-wasi": "npm:1.0.1"
+    "@rolldown/binding-win32-arm64-msvc": "npm:1.0.1"
+    "@rolldown/binding-win32-x64-msvc": "npm:1.0.1"
+    "@rolldown/pluginutils": "npm:^1.0.0"
+  dependenciesMeta:
+    "@rolldown/binding-android-arm64":
+      optional: true
+    "@rolldown/binding-darwin-arm64":
+      optional: true
+    "@rolldown/binding-darwin-x64":
+      optional: true
+    "@rolldown/binding-freebsd-x64":
+      optional: true
+    "@rolldown/binding-linux-arm-gnueabihf":
+      optional: true
+    "@rolldown/binding-linux-arm64-gnu":
+      optional: true
+    "@rolldown/binding-linux-arm64-musl":
+      optional: true
+    "@rolldown/binding-linux-ppc64-gnu":
+      optional: true
+    "@rolldown/binding-linux-s390x-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-gnu":
+      optional: true
+    "@rolldown/binding-linux-x64-musl":
+      optional: true
+    "@rolldown/binding-openharmony-arm64":
+      optional: true
+    "@rolldown/binding-wasm32-wasi":
+      optional: true
+    "@rolldown/binding-win32-arm64-msvc":
+      optional: true
+    "@rolldown/binding-win32-x64-msvc":
+      optional: true
+  bin:
+    rolldown: bin/cli.mjs
+  checksum: 10c0/0631c071874e1471c33923905061fa514fce2bd43c2e741adcddcaa4d9beaa2ba7a5d14af130d53753d838823e15b59f5acef7d24fb83ffb7aef15933b78e7d3
+  languageName: node
+  linkType: hard
+
 "router@npm:^2.2.0":
   version: 2.2.0
   resolution: "router@npm:2.2.0"
@@ -1546,6 +2292,15 @@ __metadata:
   bin:
     semver: bin/semver.js
   checksum: 10c0/aca305edfbf2383c22571cb7714f48cadc7ac95371b4b52362fb8eeffdfbc0de0669368b82b2b15978f8848f01d7114da65697e56cd8c37b0dab8c58e543f9ea
+  languageName: node
+  linkType: hard
+
+"semver@npm:^7.5.3":
+  version: 7.8.0
+  resolution: "semver@npm:7.8.0"
+  bin:
+    semver: bin/semver.js
+  checksum: 10c0/8f096ca9b80ffd47b308d03f9ce8c873e27e2983f36023c559cdc92c51e8433fc23ebbfe57ec9623fc155636a6961ee989501099841ae4bb1babc8d2b3f048cd
   languageName: node
   linkType: hard
 
@@ -1589,6 +2344,7 @@ __metadata:
     "@types/dotenv": "npm:^8.2.3"
     "@types/express": "npm:^5.0.3"
     "@types/node": "npm:^24.2.1"
+    "@vitest/coverage-v8": "npm:^4.1.6"
     better-sqlite3: "npm:^12.10.0"
     cors: "npm:^2.8.5"
     dotenv: "npm:^17.2.1"
@@ -1597,6 +2353,7 @@ __metadata:
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.2"
     uuid: "npm:^11.1.0"
+    vitest: "npm:^4.1.6"
   languageName: unknown
   linkType: soft
 
@@ -1671,6 +2428,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"siginfo@npm:^2.0.0":
+  version: 2.0.0
+  resolution: "siginfo@npm:2.0.0"
+  checksum: 10c0/3def8f8e516fbb34cb6ae415b07ccc5d9c018d85b4b8611e3dc6f8be6d1899f693a4382913c9ed51a06babb5201639d76453ab297d1c54a456544acf5c892e34
+  languageName: node
+  linkType: hard
+
 "signal-exit@npm:^4.0.1":
   version: 4.1.0
   resolution: "signal-exit@npm:4.1.0"
@@ -1724,12 +2488,26 @@ __metadata:
   languageName: node
   linkType: hard
 
+"source-map-js@npm:^1.2.1":
+  version: 1.2.1
+  resolution: "source-map-js@npm:1.2.1"
+  checksum: 10c0/7bda1fc4c197e3c6ff17de1b8b2c20e60af81b63a52cb32ec5a5d67a20a7d42651e2cb34ebe93833c5a2a084377e17455854fee3e21e7925c64a51b6a52b0faf
+  languageName: node
+  linkType: hard
+
 "ssri@npm:^12.0.0":
   version: 12.0.0
   resolution: "ssri@npm:12.0.0"
   dependencies:
     minipass: "npm:^7.0.3"
   checksum: 10c0/caddd5f544b2006e88fa6b0124d8d7b28208b83c72d7672d5ade44d794525d23b540f3396108c4eb9280dcb7c01f0bef50682f5b4b2c34291f7c5e211fd1417d
+  languageName: node
+  linkType: hard
+
+"stackback@npm:0.0.2":
+  version: 0.0.2
+  resolution: "stackback@npm:0.0.2"
+  checksum: 10c0/89a1416668f950236dd5ac9f9a6b2588e1b9b62b1b6ad8dff1bfc5d1a15dbf0aafc9b52d2226d00c28dffff212da464eaeebfc6b7578b9d180cef3e3782c5983
   languageName: node
   linkType: hard
 
@@ -1744,6 +2522,13 @@ __metadata:
   version: 2.0.2
   resolution: "statuses@npm:2.0.2"
   checksum: 10c0/a9947d98ad60d01f6b26727570f3bcceb6c8fa789da64fe6889908fe2e294d57503b14bf2b5af7605c2d36647259e856635cd4c49eab41667658ec9d0080ec3f
+  languageName: node
+  linkType: hard
+
+"std-env@npm:^4.0.0-rc.1":
+  version: 4.1.0
+  resolution: "std-env@npm:4.1.0"
+  checksum: 10c0/2e14b6b490db34cb969a48d9cf7c35bca4a47653914aac2814221baae7b867a5b15940d133625c391621971f98cd2266a5dc7036669960e883f1081db2a56558
   languageName: node
   linkType: hard
 
@@ -1803,6 +2588,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"supports-color@npm:^7.1.0":
+  version: 7.2.0
+  resolution: "supports-color@npm:7.2.0"
+  dependencies:
+    has-flag: "npm:^4.0.0"
+  checksum: 10c0/afb4c88521b8b136b5f5f95160c98dee7243dc79d5432db7efc27efb219385bbc7d9427398e43dd6cc730a0f87d5085ce1652af7efbe391327bc0a7d0f7fc124
+  languageName: node
+  linkType: hard
+
 "tar-fs@npm:^2.0.0":
   version: 2.1.3
   resolution: "tar-fs@npm:2.1.3"
@@ -1842,6 +2636,20 @@ __metadata:
   languageName: node
   linkType: hard
 
+"tinybench@npm:^2.9.0":
+  version: 2.9.0
+  resolution: "tinybench@npm:2.9.0"
+  checksum: 10c0/c3500b0f60d2eb8db65250afe750b66d51623057ee88720b7f064894a6cb7eb93360ca824a60a31ab16dab30c7b1f06efe0795b352e37914a9d4bad86386a20c
+  languageName: node
+  linkType: hard
+
+"tinyexec@npm:^1.0.2":
+  version: 1.1.2
+  resolution: "tinyexec@npm:1.1.2"
+  checksum: 10c0/9e0ef6c001ce54688cf16833a02f70a339276219ca947b88930b124267de2cffc764ff44e87e7369384b1d75ab63491465412cbbdf06f2437956b9ab66ab4491
+  languageName: node
+  linkType: hard
+
 "tinyglobby@npm:^0.2.12":
   version: 0.2.14
   resolution: "tinyglobby@npm:0.2.14"
@@ -1849,6 +2657,23 @@ __metadata:
     fdir: "npm:^6.4.4"
     picomatch: "npm:^4.0.2"
   checksum: 10c0/f789ed6c924287a9b7d3612056ed0cda67306cd2c80c249fd280cf1504742b12583a2089b61f4abbd24605f390809017240e250241f09938054c9b363e51c0a6
+  languageName: node
+  linkType: hard
+
+"tinyglobby@npm:^0.2.15, tinyglobby@npm:^0.2.16":
+  version: 0.2.16
+  resolution: "tinyglobby@npm:0.2.16"
+  dependencies:
+    fdir: "npm:^6.5.0"
+    picomatch: "npm:^4.0.4"
+  checksum: 10c0/f2e09fd93dd95c41e522113b686ff6f7c13020962f8698a864a257f3d7737599afc47722b7ab726e12f8a813f779906187911ff8ee6701ede65072671a7e934b
+  languageName: node
+  linkType: hard
+
+"tinyrainbow@npm:^3.1.0":
+  version: 3.1.0
+  resolution: "tinyrainbow@npm:3.1.0"
+  checksum: 10c0/f11cf387a26c5c9255bec141a90ac511b26172981b10c3e50053bc6700ea7d2336edcc4a3a21dbb8412fe7c013477d2ba4d7e4877800f3f8107be5105aad6511
   languageName: node
   linkType: hard
 
@@ -1894,6 +2719,13 @@ __metadata:
     ts-node-transpile-only: dist/bin-transpile.js
     ts-script: dist/bin-script-deprecated.js
   checksum: 10c0/5f29938489f96982a25ba650b64218e83a3357d76f7bede80195c65ab44ad279c8357264639b7abdd5d7e75fc269a83daa0e9c62fd8637a3def67254ecc9ddc2
+  languageName: node
+  linkType: hard
+
+"tslib@npm:^2.4.0":
+  version: 2.8.1
+  resolution: "tslib@npm:2.8.1"
+  checksum: 10c0/9c4759110a19c53f992d9aae23aac5ced636e99887b51b9e61def52611732872ff7668757d4e4c61f19691e36f4da981cd9485e869b4a7408d689f6bf1f14e62
   languageName: node
   linkType: hard
 
@@ -1999,6 +2831,131 @@ __metadata:
   languageName: node
   linkType: hard
 
+"vite@npm:^6.0.0 || ^7.0.0 || ^8.0.0":
+  version: 8.0.13
+  resolution: "vite@npm:8.0.13"
+  dependencies:
+    fsevents: "npm:~2.3.3"
+    lightningcss: "npm:^1.32.0"
+    picomatch: "npm:^4.0.4"
+    postcss: "npm:^8.5.14"
+    rolldown: "npm:1.0.1"
+    tinyglobby: "npm:^0.2.16"
+  peerDependencies:
+    "@types/node": ^20.19.0 || >=22.12.0
+    "@vitejs/devtools": ^0.1.18
+    esbuild: ^0.27.0 || ^0.28.0
+    jiti: ">=1.21.0"
+    less: ^4.0.0
+    sass: ^1.70.0
+    sass-embedded: ^1.70.0
+    stylus: ">=0.54.8"
+    sugarss: ^5.0.0
+    terser: ^5.16.0
+    tsx: ^4.8.1
+    yaml: ^2.4.2
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  peerDependenciesMeta:
+    "@types/node":
+      optional: true
+    "@vitejs/devtools":
+      optional: true
+    esbuild:
+      optional: true
+    jiti:
+      optional: true
+    less:
+      optional: true
+    sass:
+      optional: true
+    sass-embedded:
+      optional: true
+    stylus:
+      optional: true
+    sugarss:
+      optional: true
+    terser:
+      optional: true
+    tsx:
+      optional: true
+    yaml:
+      optional: true
+  bin:
+    vite: bin/vite.js
+  checksum: 10c0/8f4d6fd30c3be710f76dba8ee7cd156902200e649884911cfa8e6e5f7ad4dd5b6933bdd4f0c46c0169c49ddce9ce1bfab6d395df9d176c0d959e3ba0e5ee54e4
+  languageName: node
+  linkType: hard
+
+"vitest@npm:^4.1.6":
+  version: 4.1.6
+  resolution: "vitest@npm:4.1.6"
+  dependencies:
+    "@vitest/expect": "npm:4.1.6"
+    "@vitest/mocker": "npm:4.1.6"
+    "@vitest/pretty-format": "npm:4.1.6"
+    "@vitest/runner": "npm:4.1.6"
+    "@vitest/snapshot": "npm:4.1.6"
+    "@vitest/spy": "npm:4.1.6"
+    "@vitest/utils": "npm:4.1.6"
+    es-module-lexer: "npm:^2.0.0"
+    expect-type: "npm:^1.3.0"
+    magic-string: "npm:^0.30.21"
+    obug: "npm:^2.1.1"
+    pathe: "npm:^2.0.3"
+    picomatch: "npm:^4.0.3"
+    std-env: "npm:^4.0.0-rc.1"
+    tinybench: "npm:^2.9.0"
+    tinyexec: "npm:^1.0.2"
+    tinyglobby: "npm:^0.2.15"
+    tinyrainbow: "npm:^3.1.0"
+    vite: "npm:^6.0.0 || ^7.0.0 || ^8.0.0"
+    why-is-node-running: "npm:^2.3.0"
+  peerDependencies:
+    "@edge-runtime/vm": "*"
+    "@opentelemetry/api": ^1.9.0
+    "@types/node": ^20.0.0 || ^22.0.0 || >=24.0.0
+    "@vitest/browser-playwright": 4.1.6
+    "@vitest/browser-preview": 4.1.6
+    "@vitest/browser-webdriverio": 4.1.6
+    "@vitest/coverage-istanbul": 4.1.6
+    "@vitest/coverage-v8": 4.1.6
+    "@vitest/ui": 4.1.6
+    happy-dom: "*"
+    jsdom: "*"
+    vite: ^6.0.0 || ^7.0.0 || ^8.0.0
+  peerDependenciesMeta:
+    "@edge-runtime/vm":
+      optional: true
+    "@opentelemetry/api":
+      optional: true
+    "@types/node":
+      optional: true
+    "@vitest/browser-playwright":
+      optional: true
+    "@vitest/browser-preview":
+      optional: true
+    "@vitest/browser-webdriverio":
+      optional: true
+    "@vitest/coverage-istanbul":
+      optional: true
+    "@vitest/coverage-v8":
+      optional: true
+    "@vitest/ui":
+      optional: true
+    happy-dom:
+      optional: true
+    jsdom:
+      optional: true
+    vite:
+      optional: false
+  bin:
+    vitest: vitest.mjs
+  checksum: 10c0/1da4c23f02cd39cb20a857d48462d1d6100eeb4644fc0defc7c6eef9d481f85d2598b72d39eb4a8d271fafa8328ac3ffcca11b27865385e88d9d65c8b29b8091
+  languageName: node
+  linkType: hard
+
 "which@npm:^2.0.1":
   version: 2.0.2
   resolution: "which@npm:2.0.2"
@@ -2018,6 +2975,18 @@ __metadata:
   bin:
     node-which: bin/which.js
   checksum: 10c0/e556e4cd8b7dbf5df52408c9a9dd5ac6518c8c5267c8953f5b0564073c66ed5bf9503b14d876d0e9c7844d4db9725fb0dcf45d6e911e17e26ab363dc3965ae7b
+  languageName: node
+  linkType: hard
+
+"why-is-node-running@npm:^2.3.0":
+  version: 2.3.0
+  resolution: "why-is-node-running@npm:2.3.0"
+  dependencies:
+    siginfo: "npm:^2.0.0"
+    stackback: "npm:0.0.2"
+  bin:
+    why-is-node-running: cli.js
+  checksum: 10c0/1cde0b01b827d2cf4cb11db962f3958b9175d5d9e7ac7361d1a7b0e2dc6069a263e69118bd974c4f6d0a890ef4eedfe34cf3d5167ec14203dbc9a18620537054
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Set up Vitest and add unit tests for the server's service, middleware,
and validator layers, run against an in-memory SQLite database.

- Add vitest and @vitest/coverage-v8, plus test/test:watch/test:coverage
  scripts
- vitest.config.ts: node environment, in-memory DB, and injected test
  admin credentials
- src/__tests__/setup.ts: seed the schema once before the suite runs
- Tests:
  - services/event: create/read/update/delete, max_attendees and
    registrationOpensAt handling, ordering, and Unicode/RTL round-trips
  - services/rsvp: token generation, guest defaults, token-scoped updates,
    getMyRsvps, duplicate-id collision, and event cascade delete
  - services/poll: create/close/reopen/update/delete, vote casting,
    re-voting, and option validation (incl. mixed and cross-poll ids)
  - middleware/auth: isAdminRequest / authenticateAdmin credential checks
  - validators/isValidStatus
- config: skip loading .env when NODE_ENV=test so the suite uses only the
  injected test environment
- tsconfig: exclude __tests__ from the build
- README: document how to run the tests

Test comments flag a few existing issues for follow-up: the non-standard
(non-base64) Basic auth and its non-constant-time comparison, the lack of a
duplicate-poll-per-event guard, the token field returned by
updateRsvpByToken, the reliance on insertion order for equally timestamped
poll options, and the snake_case/camelCase Event type drift.
