### PR TITLE
Add CI workflow to run server tests on pull requests

### DIFF
--- a/.github/workflows/server-tests.yml
+++ b/.github/workflows/server-tests.yml
@@ -1,0 +1,43 @@
+name: Server tests
+
+on:
+  pull_request:
+    paths:
+      - 'server/**'
+      - '.github/workflows/server-tests.yml'
+
+jobs:
+  test:
+    name: Tests
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: server
+    env:
+      # Force a project-local Yarn cache so the cache step below is deterministic.
+      YARN_ENABLE_GLOBAL_CACHE: 'false'
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node
+        uses: actions/setup-node@v4
+        with:
+          node-version-file: server/.nvmrc
+
+      - name: Enable Corepack
+        run: corepack enable
+
+      - name: Restore Yarn cache
+        uses: actions/cache@v4
+        with:
+          path: server/.yarn/cache
+          key: yarn-${{ runner.os }}-${{ hashFiles('server/yarn.lock') }}
+          restore-keys: |
+            yarn-${{ runner.os }}-
+
+      - name: Install dependencies
+        run: yarn install --immutable
+
+      - name: Run tests
+        run: yarn test


### PR DESCRIPTION
Runs the server Vitest suite on pull requests that touch server/ (or the
workflow itself): checkout, set up Node from server/.nvmrc, enable Corepack
for Yarn 4, install with --immutable, and run `yarn test`. A project-local
Yarn cache is restored to speed up installs.
