### PR TITLE
Add client component tests with @testing-library/svelte

### DIFF
--- a/client/README.md
+++ b/client/README.md
@@ -47,4 +47,7 @@ yarn test:watch    # watch mode
 yarn test:coverage # with coverage
 ```
 
-Tests live in `src/__tests__/`.
+Tests live in `src/__tests__/`:
+- `utils/` — unit tests for the utility functions
+- `components/` and `routes/` — component and page tests rendered with
+  [@testing-library/svelte](https://testing-library.com/docs/svelte-testing-library/intro/)

--- a/client/src/__mocks__/app-navigation.ts
+++ b/client/src/__mocks__/app-navigation.ts
@@ -1,0 +1,8 @@
+import { vi } from 'vitest';
+
+export const goto = vi.fn();
+export const invalidateAll = vi.fn();
+export const pushState = vi.fn();
+export const replaceState = vi.fn();
+export const preloadCode = vi.fn();
+export const preloadData = vi.fn();

--- a/client/src/__tests__/components/AttendeeList.test.ts
+++ b/client/src/__tests__/components/AttendeeList.test.ts
@@ -1,0 +1,211 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import AttendeeList from '$lib/AttendeeList.svelte';
+import type { Rsvp } from '../../types/Rsvp';
+
+afterEach(cleanup);
+
+function makeRsvp(overrides: Partial<Rsvp> = {}): Rsvp {
+  return {
+    id: 'r1',
+    name: 'Alice',
+    event_id: 'e1',
+    status: 'going',
+    guests: 0,
+    token: 'tok',
+    ...overrides,
+  };
+}
+
+describe('AttendeeList', () => {
+  it('renders nothing when attendees array is empty', () => {
+    render(AttendeeList, { props: { attendees: [] } });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('list')).not.toBeInTheDocument();
+  });
+
+  it('shows a toggle button with the attendee count', () => {
+    const attendees = [makeRsvp({ name: 'Alice' }), makeRsvp({ id: 'r2', name: 'Bob' })];
+    render(AttendeeList, { props: { attendees, maxAttendees: 10 } });
+    expect(screen.getByRole('button', { name: /Show Responses \(2\)/ })).toBeInTheDocument();
+  });
+
+  it('does not show attendee names before toggle is clicked', () => {
+    render(AttendeeList, { props: { attendees: [makeRsvp({ name: 'Alice' })], maxAttendees: 10 } });
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('reveals attendee names when toggle is clicked', async () => {
+    render(AttendeeList, { props: { attendees: [makeRsvp({ name: 'Alice' })], maxAttendees: 10 } });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+  });
+
+  it('hides the list again when toggle is clicked a second time', async () => {
+    render(AttendeeList, { props: { attendees: [makeRsvp({ name: 'Alice' })], maxAttendees: 10 } });
+    const toggle = screen.getByRole('button', { name: /Show Responses/ });
+    await fireEvent.click(toggle);
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    await fireEvent.click(screen.getByRole('button', { name: /Hide Responses/ }));
+    expect(screen.queryByText('Alice')).not.toBeInTheDocument();
+  });
+
+  it('tracks open state in aria-expanded', async () => {
+    render(AttendeeList, { props: { attendees: [makeRsvp()], maxAttendees: 10 } });
+    const toggle = screen.getByRole('button', { name: /Show Responses/ });
+    expect(toggle).toHaveAttribute('aria-expanded', 'false');
+    await fireEvent.click(toggle);
+    expect(screen.getByRole('button', { name: /Hide Responses/ })).toHaveAttribute('aria-expanded', 'true');
+  });
+
+  it('shows Going group header when going attendees are present', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ status: 'going' })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Going')).toBeInTheDocument();
+  });
+
+  it('shows Maybe group header when maybe attendees are present', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ status: 'maybe' })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Maybe')).toBeInTheDocument();
+  });
+
+  it('shows Not Going group header when not_going attendees are present', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ status: 'not_going' })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Not Going')).toBeInTheDocument();
+  });
+
+  it('shows only going attendees up to maxAttendees in the Going section', async () => {
+    const attendees = [
+      makeRsvp({ id: 'r1', name: 'Alice', status: 'going' }),
+      makeRsvp({ id: 'r2', name: 'Bob', status: 'going' }),
+      makeRsvp({ id: 'r3', name: 'Charlie', status: 'going' }),
+    ];
+    render(AttendeeList, { props: { attendees, maxAttendees: 2 } });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    // Alice and Bob appear in Going; Charlie overflows to Waitlist
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('shows a Waitlist section when going attendees exceed maxAttendees', async () => {
+    const attendees = [
+      makeRsvp({ id: 'r1', name: 'Alice', status: 'going' }),
+      makeRsvp({ id: 'r2', name: 'Bob', status: 'going' }),
+      makeRsvp({ id: 'r3', name: 'Charlie', status: 'going' }),
+    ];
+    render(AttendeeList, { props: { attendees, maxAttendees: 2 } });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Waitlist')).toBeInTheDocument();
+  });
+
+  it('does not show Waitlist when going attendees fit within maxAttendees', async () => {
+    const attendees = [makeRsvp({ id: 'r1', status: 'going' })];
+    render(AttendeeList, { props: { attendees, maxAttendees: 5 } });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.queryByText('Waitlist')).not.toBeInTheDocument();
+  });
+
+  it('shows delete buttons when showDeleteButton is true', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp()], maxAttendees: 10, showDeleteButton: true },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getAllByRole('button', { name: 'Delete attendee' }).length).toBeGreaterThan(0);
+  });
+
+  it('hides delete buttons when showDeleteButton is false', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp()], maxAttendees: 10, showDeleteButton: false },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.queryByRole('button', { name: 'Delete attendee' })).not.toBeInTheDocument();
+  });
+
+  it('calls onDelete with the correct id when delete button is clicked', async () => {
+    const onDelete = vi.fn();
+    render(AttendeeList, {
+      props: {
+        attendees: [makeRsvp({ id: 'rsvp-xyz', status: 'going' })],
+        maxAttendees: 10,
+        showDeleteButton: true,
+        onDelete,
+      },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Delete attendee' }));
+    expect(onDelete).toHaveBeenCalledOnce();
+    expect(onDelete).toHaveBeenCalledWith('rsvp-xyz');
+  });
+
+  it('shows guest count for attendees with extra guests', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ guests: 2 })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('(+2 guests)')).toBeInTheDocument();
+  });
+
+  it('shows singular guest label for exactly one guest', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ guests: 1 })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('(+1 guest)')).toBeInTheDocument();
+  });
+
+  it('does not show guest count for zero guests', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ guests: 0 })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.queryByText(/guest/)).not.toBeInTheDocument();
+  });
+
+  it('groups attendees correctly across all three statuses', async () => {
+    const attendees = [
+      makeRsvp({ id: 'r1', name: 'Alice', status: 'going' }),
+      makeRsvp({ id: 'r2', name: 'Bob', status: 'maybe' }),
+      makeRsvp({ id: 'r3', name: 'Charlie', status: 'not_going' }),
+    ];
+    render(AttendeeList, { props: { attendees, maxAttendees: 10 } });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Going')).toBeInTheDocument();
+    expect(screen.getByText('Maybe')).toBeInTheDocument();
+    expect(screen.getByText('Not Going')).toBeInTheDocument();
+    expect(screen.getByText('Alice')).toBeInTheDocument();
+    expect(screen.getByText('Bob')).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('toggle button has aria-controls pointing to the list element id', async () => {
+    render(AttendeeList, { props: { attendees: [makeRsvp()], maxAttendees: 10 } });
+    const toggle = screen.getByRole('button', { name: /Show Responses/ });
+    expect(toggle).toHaveAttribute('aria-controls', 'attendees-list');
+  });
+
+  it('the controlled list element has the id referenced by aria-controls', async () => {
+    render(AttendeeList, { props: { attendees: [makeRsvp()], maxAttendees: 10 } });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(document.getElementById('attendees-list')).toBeInTheDocument();
+  });
+
+  it('renders attendee name containing XSS payload as text, not as markup', async () => {
+    const xssName = '<img src=x onerror=alert(1)>';
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ name: xssName })], maxAttendees: 10 },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    // The name text should be visible and no <img> should have been injected
+    expect(screen.getByText(xssName)).toBeInTheDocument();
+    expect(document.querySelector('img[src="x"]')).toBeNull();
+  });
+});

--- a/client/src/__tests__/components/Footer.test.ts
+++ b/client/src/__tests__/components/Footer.test.ts
@@ -1,0 +1,26 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import Footer from '$lib/Footer.svelte';
+
+afterEach(cleanup);
+
+describe('Footer', () => {
+  it('renders a footer element', () => {
+    render(Footer);
+    expect(screen.getByRole('contentinfo')).toBeInTheDocument();
+  });
+
+  it('displays creator credits', () => {
+    render(Footer);
+    const footer = screen.getByRole('contentinfo');
+    expect(footer).toHaveTextContent('Hemang');
+    expect(footer).toHaveTextContent('James');
+    expect(footer).toHaveTextContent('Miguel');
+    expect(footer).toHaveTextContent('Teppo');
+  });
+
+  it('contains a heart symbol', () => {
+    render(Footer);
+    expect(screen.getByRole('contentinfo')).toHaveTextContent('♥');
+  });
+});

--- a/client/src/__tests__/components/Header.test.ts
+++ b/client/src/__tests__/components/Header.test.ts
@@ -1,0 +1,108 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup, waitFor } from '@testing-library/svelte';
+import Header from '$lib/Header.svelte';
+
+afterEach(cleanup);
+
+function renderHeader() {
+  const setMenuOpen = vi.fn();
+  const result = render(Header, {
+    context: new Map([['setMenuOpen', setMenuOpen]]),
+  });
+  return { ...result, setMenuOpen };
+}
+
+describe('Header', () => {
+  it('renders the site logo link', () => {
+    renderHeader();
+    expect(screen.getByRole('link', { name: 'Event RSVP Tool' })).toBeInTheDocument();
+  });
+
+  it('logo link points to home page', () => {
+    renderHeader();
+    expect(screen.getByRole('link', { name: 'Event RSVP Tool' })).toHaveAttribute('href', '/');
+  });
+
+  it('renders the hamburger menu button', () => {
+    renderHeader();
+    expect(screen.getByRole('button', { name: 'Open menu' })).toBeInTheDocument();
+  });
+
+  it('sidebar is not visible initially', () => {
+    renderHeader();
+    expect(screen.queryByRole('navigation', { name: 'Sidebar navigation' })).not.toBeInTheDocument();
+  });
+
+  it('opens the sidebar when the menu button is clicked', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByRole('navigation', { name: 'Sidebar navigation' })).toBeInTheDocument();
+  });
+
+  it('sidebar contains expected navigation links', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const nav = screen.getByRole('navigation', { name: 'Sidebar navigation' });
+    expect(nav).toHaveTextContent('Home');
+    expect(nav).toHaveTextContent('Events');
+    expect(nav).toHaveTextContent('My RSVPs');
+    expect(nav).toHaveTextContent('Create Event');
+    expect(nav).toHaveTextContent('Admin Login');
+  });
+
+  it('closes the sidebar when the close button is clicked', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByRole('navigation', { name: 'Sidebar navigation' })).toBeInTheDocument();
+
+    await fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+    expect(screen.queryByRole('navigation', { name: 'Sidebar navigation' })).not.toBeInTheDocument();
+  });
+
+  it('closes the sidebar when the backdrop is clicked', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const backdrop = document.querySelector('[aria-hidden="true"]')!;
+    await fireEvent.click(backdrop);
+    expect(screen.queryByRole('navigation', { name: 'Sidebar navigation' })).not.toBeInTheDocument();
+  });
+
+  it('closes the sidebar on Escape key press', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(screen.getByRole('navigation', { name: 'Sidebar navigation' })).toBeInTheDocument();
+
+    await fireEvent.keyDown(window, { key: 'Escape' });
+    expect(screen.queryByRole('navigation', { name: 'Sidebar navigation' })).not.toBeInTheDocument();
+  });
+
+  it('calls setMenuOpen(true) when sidebar opens', async () => {
+    const { setMenuOpen } = renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    expect(setMenuOpen).toHaveBeenCalledWith(true);
+  });
+
+  it('calls setMenuOpen(false) when sidebar closes', async () => {
+    const { setMenuOpen } = renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Close menu' }));
+    expect(setMenuOpen).toHaveBeenCalledWith(false);
+  });
+
+  it('moves focus to the close button when the sidebar opens', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Close menu' })).toHaveFocus();
+    });
+  });
+
+  it('closes sidebar when a navigation link is clicked', async () => {
+    renderHeader();
+    await fireEvent.click(screen.getByRole('button', { name: 'Open menu' }));
+    const homeLink = screen.getByRole('navigation', { name: 'Sidebar navigation' })
+      .querySelector('a[href="/"]')!;
+    await fireEvent.click(homeLink);
+    expect(screen.queryByRole('navigation', { name: 'Sidebar navigation' })).not.toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/MapLink.test.ts
+++ b/client/src/__tests__/components/MapLink.test.ts
@@ -1,0 +1,44 @@
+import { afterEach, describe, it, expect } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import MapLink from '$lib/MapLink.svelte';
+
+afterEach(cleanup);
+
+describe('MapLink', () => {
+  it('renders a link with the address as visible text', () => {
+    render(MapLink, { props: { address: '123 Main St, Berlin' } });
+    expect(screen.getByRole('link', { name: '123 Main St, Berlin' })).toBeInTheDocument();
+  });
+
+  it('opens in a new tab', () => {
+    render(MapLink, { props: { address: '123 Main St' } });
+    expect(screen.getByRole('link')).toHaveAttribute('target', '_blank');
+  });
+
+  it('has rel=noopener for security', () => {
+    render(MapLink, { props: { address: '123 Main St' } });
+    expect(screen.getByRole('link')).toHaveAttribute('rel', 'noopener');
+  });
+
+  it('uses a Google Maps URL in jsdom environment (non-mobile UA)', () => {
+    // jsdom UA does not contain iPad/iPhone/Macintosh/android, so the
+    // fallback Google Maps web URL is used.
+    render(MapLink, { props: { address: 'Berliner Str. 1, Berlin' } });
+    const href = screen.getByRole('link').getAttribute('href') ?? '';
+    expect(href).toContain('google.com/maps');
+    // encodeURIComponent uses %20 for spaces, not +
+    expect(href).toContain('Berliner%20Str.%201%2C%20Berlin');
+  });
+
+  it('encodes the address into the href', () => {
+    render(MapLink, { props: { address: 'Some Place & Venue' } });
+    const href = screen.getByRole('link').getAttribute('href') ?? '';
+    expect(href).toContain(encodeURIComponent('Some Place & Venue'));
+  });
+
+  it('uses address as link text even when label prop differs', () => {
+    render(MapLink, { props: { address: '10 Downing St', label: 'The Office' } });
+    // The displayed text is always the address, label is only used in geo URIs
+    expect(screen.getByRole('link', { name: '10 Downing St' })).toBeInTheDocument();
+  });
+});

--- a/client/src/__tests__/components/PollWidget.test.ts
+++ b/client/src/__tests__/components/PollWidget.test.ts
@@ -1,0 +1,371 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import PollWidget from '$lib/PollWidget.svelte';
+import type { Poll } from '../../types/Poll';
+import type { User } from '../../types/User';
+
+afterEach(cleanup);
+
+const openPoll: Poll = {
+  id: 'poll-1',
+  event_id: 'evt-1',
+  title: 'Vote for tonight\'s script',
+  status: 'open',
+  created_at: '2024-01-01T00:00:00.000Z',
+  options: [
+    {
+      id: 'opt-1',
+      poll_id: 'poll-1',
+      name: 'Script A',
+      url: 'https://example.com/a',
+      description: 'A description',
+      created_at: '2024-01-01T00:00:00.000Z',
+      votes: [],
+    },
+    {
+      id: 'opt-2',
+      poll_id: 'poll-1',
+      name: 'Script B',
+      url: 'https://example.com/b',
+      description: '',
+      created_at: '2024-01-01T00:00:00.000Z',
+      votes: [{ rsvp_id: 'rsvp-x', voter_name: 'Dave' }],
+    },
+  ],
+};
+
+const closedPoll: Poll = {
+  ...openPoll,
+  status: 'closed',
+  options: [
+    {
+      id: 'opt-1',
+      poll_id: 'poll-1',
+      name: 'Script A',
+      url: 'https://example.com/a',
+      created_at: '2024-01-01T00:00:00.000Z',
+      votes: [
+        { rsvp_id: 'rsvp-a', voter_name: 'Alice' },
+        { rsvp_id: 'rsvp-b', voter_name: 'Bob' },
+      ],
+    },
+    {
+      id: 'opt-2',
+      poll_id: 'poll-1',
+      name: 'Script B',
+      url: 'https://example.com/b',
+      created_at: '2024-01-01T00:00:00.000Z',
+      votes: [{ rsvp_id: 'rsvp-c', voter_name: 'Charlie' }],
+    },
+  ],
+};
+
+const loggedInUser: User = { id: 'rsvp-x', token: 'token-x' };
+
+describe('PollWidget — no poll', () => {
+  it('renders nothing visible when poll is null and user is not admin', () => {
+    render(PollWidget, {
+      props: { poll: null, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.queryByRole('button')).not.toBeInTheDocument();
+    expect(screen.queryByRole('heading')).not.toBeInTheDocument();
+  });
+
+  it('shows Add script vote button when poll is null and user is admin', () => {
+    render(PollWidget, {
+      props: { poll: null, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    expect(screen.getByRole('button', { name: /Add script vote/ })).toBeInTheDocument();
+  });
+
+  it('shows create form when admin clicks Add script vote', async () => {
+    render(PollWidget, {
+      props: { poll: null, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Add script vote/ }));
+    expect(screen.getByText('Create script vote')).toBeInTheDocument();
+    expect(screen.getByPlaceholderText(/Vote for tonight/)).toBeInTheDocument();
+  });
+
+  it('cancels the create form when Cancel is clicked', async () => {
+    render(PollWidget, {
+      props: { poll: null, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Add script vote/ }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByText('Create script vote')).not.toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /Add script vote/ })).toBeInTheDocument();
+  });
+
+  it('shows validation error when submitting create form without data', async () => {
+    render(PollWidget, {
+      props: { poll: null, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Add script vote/ }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Create poll' }));
+    expect(screen.getByText(/title and at least one option/i)).toBeInTheDocument();
+  });
+});
+
+describe('PollWidget — open poll', () => {
+  it('displays the poll title', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText("Vote for tonight's script")).toBeInTheDocument();
+  });
+
+  it('shows Voting open status badge', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText('Voting open')).toBeInTheDocument();
+  });
+
+  it('shows all option names', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText('Script A')).toBeInTheDocument();
+    expect(screen.getByText('Script B')).toBeInTheDocument();
+  });
+
+  it('shows "RSVP first" message when no user', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText(/RSVP first to participate/)).toBeInTheDocument();
+  });
+
+  it('shows vote checkboxes when user is logged in', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    const checkboxes = screen.getAllByRole('checkbox');
+    expect(checkboxes).toHaveLength(openPoll.options.length);
+  });
+
+  it('shows Save vote button when user is logged in', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByRole('button', { name: 'Save vote' })).toBeInTheDocument();
+  });
+
+  it('pre-selects options the user has already voted for', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    const checkboxes = screen.getAllByRole('checkbox');
+    // opt-2 has a vote from rsvp-x (= loggedInUser.id), opt-1 has no vote
+    const [cbA, cbB] = checkboxes;
+    expect(cbA).not.toBeChecked();
+    expect(cbB).toBeChecked();
+  });
+
+  it('toggles checkbox when user clicks an option', async () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    const [cbA] = screen.getAllByRole('checkbox');
+    expect(cbA).not.toBeChecked();
+    await fireEvent.change(cbA);
+    expect(cbA).toBeChecked();
+  });
+
+  it('hides RSVP first message when user is logged in', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.queryByText(/RSVP first/)).not.toBeInTheDocument();
+  });
+
+  it('shows existing vote count per option', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    // Script A has 0 votes, Script B has 1
+    expect(screen.getByText('0 votes')).toBeInTheDocument();
+    expect(screen.getByText('1 vote')).toBeInTheDocument();
+  });
+
+  it('shows admin controls when isAdmin is true', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    expect(screen.getByRole('button', { name: 'Close voting' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Delete' })).toBeInTheDocument();
+  });
+
+  it('hides admin controls when isAdmin is false', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.queryByRole('button', { name: 'Close voting' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Edit' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Delete' })).not.toBeInTheDocument();
+  });
+
+  it('opens the edit form when admin clicks Edit', async () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByLabelText('Poll title')).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Save changes' })).toBeInTheDocument();
+  });
+
+  it('closes edit form when Cancel is clicked', async () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    await fireEvent.click(screen.getByRole('button', { name: 'Cancel' }));
+    expect(screen.queryByRole('button', { name: 'Save changes' })).not.toBeInTheDocument();
+  });
+
+  it('shows option description when present', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText('A description')).toBeInTheDocument();
+  });
+});
+
+describe('PollWidget — create form option management', () => {
+  async function openCreateForm() {
+    render(PollWidget, {
+      props: { poll: null, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Add script vote/ }));
+  }
+
+  it('starts with one option row and no Remove button', async () => {
+    await openCreateForm();
+    expect(screen.queryByRole('button', { name: 'Remove option' })).not.toBeInTheDocument();
+    expect(screen.getAllByPlaceholderText('Script name')).toHaveLength(1);
+  });
+
+  it('"Add another option" adds a second option row', async () => {
+    await openCreateForm();
+    await fireEvent.click(screen.getByRole('button', { name: /Add another option/ }));
+    expect(screen.getAllByPlaceholderText('Script name')).toHaveLength(2);
+    expect(screen.getAllByRole('button', { name: 'Remove option' })).toHaveLength(2);
+  });
+
+  it('"Remove option" removes that row and hides Remove buttons when only one remains', async () => {
+    await openCreateForm();
+    await fireEvent.click(screen.getByRole('button', { name: /Add another option/ }));
+    await fireEvent.click(screen.getAllByRole('button', { name: 'Remove option' })[0]);
+    expect(screen.getAllByPlaceholderText('Script name')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Remove option' })).not.toBeInTheDocument();
+  });
+});
+
+describe('PollWidget — edit form option management', () => {
+  async function openEditForm() {
+    render(PollWidget, {
+      props: { poll: openPoll, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+  }
+
+  it('edit form shows one row per poll option', async () => {
+    await openEditForm();
+    expect(screen.getAllByPlaceholderText('Script name')).toHaveLength(openPoll.options.length);
+    expect(screen.getAllByRole('button', { name: 'Remove option' })).toHaveLength(openPoll.options.length);
+  });
+
+  it('"Add another option" in edit form adds a new row', async () => {
+    await openEditForm();
+    await fireEvent.click(screen.getByRole('button', { name: /Add another option/ }));
+    expect(screen.getAllByPlaceholderText('Script name')).toHaveLength(openPoll.options.length + 1);
+    expect(screen.getAllByRole('button', { name: 'Remove option' })).toHaveLength(openPoll.options.length + 1);
+  });
+
+  it('"Remove option" in edit form removes that row', async () => {
+    await openEditForm();
+    await fireEvent.click(screen.getAllByRole('button', { name: 'Remove option' })[1]);
+    expect(screen.getAllByPlaceholderText('Script name')).toHaveLength(1);
+    expect(screen.queryByRole('button', { name: 'Remove option' })).not.toBeInTheDocument();
+  });
+});
+
+describe('PollWidget — closed poll', () => {
+  it('shows Voting closed status badge', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText('Voting closed')).toBeInTheDocument();
+  });
+
+  it('does not show vote checkboxes', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.queryByRole('checkbox')).not.toBeInTheDocument();
+  });
+
+  it('does not show Save vote button', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.queryByRole('button', { name: 'Save vote' })).not.toBeInTheDocument();
+  });
+
+  it('shows sorted results with vote counts', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText('Script A')).toBeInTheDocument();
+    expect(screen.getByText('Script B')).toBeInTheDocument();
+    expect(screen.getByText('2 votes')).toBeInTheDocument();
+    expect(screen.getByText('1 vote')).toBeInTheDocument();
+  });
+
+  it('shows voter names for closed results', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText(/Alice.*Bob|Bob.*Alice/)).toBeInTheDocument();
+    expect(screen.getByText('Charlie')).toBeInTheDocument();
+  });
+
+  it('shows Re-open button for admin when poll is closed', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    expect(screen.getByRole('button', { name: 'Re-open' })).toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: 'Close voting' })).not.toBeInTheDocument();
+  });
+
+  it('options sorted by votes descending (most voted first in the DOM)', () => {
+    render(PollWidget, {
+      props: { poll: closedPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    const items = screen.getAllByRole('listitem');
+    const scriptAIndex = items.findIndex(li => li.textContent?.includes('Script A'));
+    const scriptBIndex = items.findIndex(li => li.textContent?.includes('Script B'));
+    // Script A has 2 votes, Script B has 1 vote, so A appears before B
+    expect(scriptAIndex).toBeLessThan(scriptBIndex);
+  });
+
+  it('poll option name with XSS payload renders as text, not markup', () => {
+    const pollWithXss = {
+      ...closedPoll,
+      options: [
+        {
+          ...closedPoll.options[0],
+          name: '<img src=x onerror=alert(1)>',
+          votes: [],
+        },
+      ],
+    };
+    render(PollWidget, {
+      props: { poll: pollWithXss, user: undefined, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(document.querySelector('img[src="x"]')).toBeNull();
+    expect(document.body.textContent).toContain('<img src=x onerror=alert(1)>');
+  });
+});

--- a/client/src/__tests__/components/RSVPForm.test.ts
+++ b/client/src/__tests__/components/RSVPForm.test.ts
@@ -1,0 +1,86 @@
+import { afterEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, cleanup } from '@testing-library/svelte';
+import RSVPForm from '$lib/RSVPForm.svelte';
+
+afterEach(cleanup);
+
+const defaultProps = {
+  rsvp: 'going' as const,
+  attendeeName: '',
+  onSubmit: vi.fn(),
+  onNameInput: vi.fn(),
+};
+
+describe('RSVPForm', () => {
+  it('renders the name input', () => {
+    render(RSVPForm, { props: defaultProps });
+    expect(screen.getByLabelText(/Your Name/)).toBeInTheDocument();
+  });
+
+  it('renders all three status buttons', () => {
+    render(RSVPForm, { props: defaultProps });
+    expect(screen.getByRole('button', { name: 'Going' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Maybe' })).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: 'Not Going' })).toBeInTheDocument();
+  });
+
+  it('marks the initial status button as pressed', () => {
+    render(RSVPForm, { props: { ...defaultProps, rsvp: 'going' as const } });
+    expect(screen.getByRole('button', { name: 'Going' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Maybe' })).toHaveAttribute('aria-pressed', 'false');
+    expect(screen.getByRole('button', { name: 'Not Going' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('marks maybe as initially pressed when rsvp="maybe"', () => {
+    render(RSVPForm, { props: { ...defaultProps, rsvp: 'maybe' as const } });
+    expect(screen.getByRole('button', { name: 'Maybe' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Going' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('switches selection when a different status button is clicked', async () => {
+    render(RSVPForm, { props: { ...defaultProps, rsvp: 'going' as const } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Maybe' }));
+    expect(screen.getByRole('button', { name: 'Maybe' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Going' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('switches to Not Going when that button is clicked', async () => {
+    render(RSVPForm, { props: { ...defaultProps, rsvp: 'going' as const } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Not Going' }));
+    expect(screen.getByRole('button', { name: 'Not Going' })).toHaveAttribute('aria-pressed', 'true');
+    expect(screen.getByRole('button', { name: 'Going' })).toHaveAttribute('aria-pressed', 'false');
+  });
+
+  it('renders the submit button', () => {
+    render(RSVPForm, { props: defaultProps });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('calls onSubmit when the form is submitted', async () => {
+    const onSubmit = vi.fn();
+    render(RSVPForm, { props: { ...defaultProps, onSubmit } });
+    // Unnamed forms don't get role="form"; fire submit directly on the element
+    await fireEvent.submit(document.querySelector('form')!);
+    expect(onSubmit).toHaveBeenCalled();
+  });
+
+  it('disables the submit button when disabled prop is true', () => {
+    render(RSVPForm, { props: { ...defaultProps, disabled: true } });
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeDisabled();
+  });
+
+  it('enables the submit button when disabled prop is false', () => {
+    render(RSVPForm, { props: { ...defaultProps, disabled: false } });
+    expect(screen.getByRole('button', { name: 'Submit' })).not.toBeDisabled();
+  });
+
+  it('shows the name input as required', () => {
+    render(RSVPForm, { props: defaultProps });
+    expect(screen.getByLabelText(/Your Name/)).toBeRequired();
+  });
+
+  it('reflects attendeeName in the name input', () => {
+    render(RSVPForm, { props: { ...defaultProps, attendeeName: 'Bob' } });
+    expect(screen.getByLabelText(/Your Name/)).toHaveValue('Bob');
+  });
+});

--- a/client/src/__tests__/routes/AdminLoginPage.test.ts
+++ b/client/src/__tests__/routes/AdminLoginPage.test.ts
@@ -1,0 +1,99 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, fireEvent, waitFor, cleanup } from '@testing-library/svelte';
+import AdminLoginPage from '../../routes/admin/login/+page.svelte';
+import { goto } from '$app/navigation';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+function mockFetch(ok: boolean, status = ok ? 200 : 401) {
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok,
+      status,
+      json: async () => ({}),
+    } as Response),
+  );
+}
+
+describe('Admin login page', () => {
+  it('renders the page heading', () => {
+    render(AdminLoginPage);
+    expect(screen.getByRole('heading', { name: 'Admin Login' })).toBeInTheDocument();
+  });
+
+  it('renders username and password inputs', () => {
+    render(AdminLoginPage);
+    expect(screen.getByLabelText(/Username/)).toBeInTheDocument();
+    expect(screen.getByLabelText(/Password/)).toBeInTheDocument();
+  });
+
+  it('renders the submit button', () => {
+    render(AdminLoginPage);
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('username input is required', () => {
+    render(AdminLoginPage);
+    expect(screen.getByLabelText(/Username/)).toBeRequired();
+  });
+
+  it('password input is of type password', () => {
+    render(AdminLoginPage);
+    expect(screen.getByLabelText(/Password/)).toHaveAttribute('type', 'password');
+  });
+
+  it('shows error message when login fails', async () => {
+    mockFetch(false, 401);
+    render(AdminLoginPage);
+
+    await fireEvent.input(screen.getByLabelText(/Username/), { target: { value: 'admin' } });
+    await fireEvent.input(screen.getByLabelText(/Password/), { target: { value: 'wrong' } });
+    await fireEvent.submit(document.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(screen.getByText('Invalid username or password')).toBeInTheDocument();
+    });
+  });
+
+  it('does not show error message initially', () => {
+    render(AdminLoginPage);
+    expect(screen.queryByText('Invalid username or password')).not.toBeInTheDocument();
+  });
+
+  it('redirects to /events on successful login', async () => {
+    mockFetch(true);
+    vi.mocked(goto).mockClear();
+    render(AdminLoginPage);
+
+    await fireEvent.input(screen.getByLabelText(/Username/), { target: { value: 'admin' } });
+    await fireEvent.input(screen.getByLabelText(/Password/), { target: { value: 'correct' } });
+    await fireEvent.submit(document.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(goto).toHaveBeenCalledWith('/events');
+    });
+  });
+
+  it('stores credentials in localStorage on successful login', async () => {
+    mockFetch(true);
+    render(AdminLoginPage);
+
+    await fireEvent.input(screen.getByLabelText(/Username/), { target: { value: 'admin' } });
+    await fireEvent.input(screen.getByLabelText(/Password/), { target: { value: 'secret' } });
+    await fireEvent.submit(document.querySelector('form')!);
+
+    await waitFor(() => {
+      expect(localStorage.getItem('credentials')).toBe('admin:secret');
+    });
+  });
+
+  it('sets the page title', () => {
+    render(AdminLoginPage);
+    expect(document.title).toBe('Admin Login | Event RSVP');
+  });
+});

--- a/client/src/__tests__/routes/EventDetailPage.test.ts
+++ b/client/src/__tests__/routes/EventDetailPage.test.ts
@@ -1,0 +1,363 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, fireEvent, cleanup } from '@testing-library/svelte';
+import EventDetailPage from '../../routes/events/[id]/+page.svelte';
+import type { Event } from '../../types/Event';
+import type { Rsvp } from '../../types/Rsvp';
+import type { Poll } from '../../types/Poll';
+
+// The add-to-calendar-button web component is browser-only; stub it out so the
+// dynamic import in onMount doesn't interfere with the test environment.
+vi.mock('add-to-calendar-button', () => ({}));
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+const baseEvent: Event = {
+  id: 'evt-1',
+  name: 'Board Game Night',
+  date: '2024-06-15',
+  start_time: '19:00',
+  end_time: '22:00',
+  location: 'The Pub, Berlin',
+  max_attendees: 10,
+};
+
+function buildData(
+  event: Event | null = baseEvent,
+  rsvp: Rsvp[] = [],
+  poll: Poll | null = null,
+  clockOffset = 0,
+) {
+  return { event, rsvp, poll, clockOffset };
+}
+
+function stubFetchUnauthorized() {
+  // removeStaleLocalStorageEntries returns early when localStorage is empty.
+  // The only fetch that fires is the admin login check; return 401 so isAdmin=false.
+  vi.stubGlobal(
+    'fetch',
+    vi.fn().mockResolvedValue({
+      ok: false,
+      status: 401,
+      json: async () => ({}),
+    } as Response),
+  );
+}
+
+describe('EventDetailPage — happy path', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  it('shows the event name after mount', async () => {
+    render(EventDetailPage, { props: { data: buildData() } });
+    await waitFor(() => {
+      expect(screen.getByText('Board Game Night')).toBeInTheDocument();
+    });
+  });
+
+  it('shows the formatted event date', async () => {
+    render(EventDetailPage, { props: { data: buildData() } });
+    await waitFor(() => {
+      // formatDate produces something like "Saturday, June 15, 2024"
+      expect(screen.getByText(/June 15, 2024/)).toBeInTheDocument();
+    });
+  });
+
+  it('shows the location as a map link', async () => {
+    render(EventDetailPage, { props: { data: buildData() } });
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'The Pub, Berlin' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows the going count and max attendees', async () => {
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await waitFor(() => {
+      expect(screen.getByText(/1\/10/)).toBeInTheDocument();
+    });
+  });
+
+  it('sets the page title from the event name', async () => {
+    render(EventDetailPage, { props: { data: buildData() } });
+    await waitFor(() => {
+      expect(document.title).toBe('Board Game Night | Event RSVP');
+    });
+  });
+});
+
+describe('EventDetailPage — RSVP form visibility', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  it('shows the RSVP form when user has not responded', async () => {
+    render(EventDetailPage, { props: { data: buildData() } });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+    });
+  });
+
+  it('hides the RSVP form when user has already responded', async () => {
+    // Put an existing RSVP in localStorage so getUser finds the user
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'r1': 'tok' } }),
+    );
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await waitFor(() => {
+      expect(screen.queryByRole('button', { name: 'Submit' })).not.toBeInTheDocument();
+    });
+  });
+
+  it('shows status indicator when user has already responded', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'r1': 'tok' } }),
+    );
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await waitFor(() => {
+      expect(screen.getByText(/You are marked as/)).toBeInTheDocument();
+      expect(screen.getByText('Going')).toBeInTheDocument();
+    });
+  });
+
+  it('shows Edit button on the status indicator', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'r1': 'tok' } }),
+    );
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await waitFor(() => {
+      // The button text is "Edit" and title is "Edit RSVP" — accessible name comes from text content
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument();
+    });
+  });
+
+  it('shows the RSVP form again when Edit is clicked', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'r1': 'tok' } }),
+    );
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await waitFor(() =>
+      expect(screen.getByRole('button', { name: 'Edit' })).toBeInTheDocument(),
+    );
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+});
+
+describe('EventDetailPage — waitlist', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  it('shows waitlist status when user is on the waitlist', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'r3': 'tok3' } }),
+    );
+    // max_attendees=2, r3 is third going → waitlisted
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok1' },
+      { id: 'r2', name: 'Bob', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok2' },
+      { id: 'r3', name: 'Charlie', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok3' },
+    ];
+    const event: Event = { ...baseEvent, max_attendees: 2 };
+    render(EventDetailPage, { props: { data: buildData(event, rsvps) } });
+    await waitFor(() => {
+      expect(screen.getByText(/You are currently on the/)).toBeInTheDocument();
+      expect(screen.getByText('Waitlist')).toBeInTheDocument();
+    });
+  });
+});
+
+describe('EventDetailPage — admin view', () => {
+  it('shows admin edit link when user is admin', async () => {
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({}),
+      } as Response),
+    );
+    render(EventDetailPage, { props: { data: buildData() } });
+    // The admin edit link has aria-label="Edit event"
+    await waitFor(() => {
+      expect(screen.getByRole('link', { name: 'Edit event' })).toBeInTheDocument();
+    });
+  });
+});
+
+describe('EventDetailPage — null event (not found)', () => {
+  it('throws when rendered with a null event (BUG: no null guard)', () => {
+    // BUG: the page's instance script dereferences event.id and
+    // event.registration_opens_at unconditionally, so a not-found event
+    // (data.event === null) crashes the component on mount instead of rendering
+    // the "No Such Event was found!" message. The script should null-guard event
+    // (and the <svelte:head> block) before reading its fields.
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) } as Response),
+    );
+    expect(() => render(EventDetailPage, { props: { data: buildData(null) } })).toThrow();
+  });
+});
+
+describe('EventDetailPage — +1 button', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  it('shows "Bringing a +1? Click here" button when user has already responded', async () => {
+    localStorage.setItem('my_events', JSON.stringify({ 'evt-1': { 'r1': 'tok' } }));
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await waitFor(() => {
+      expect(screen.getByRole('button', { name: /Bringing a \+1/ })).toBeInTheDocument();
+    });
+  });
+
+  it('clicking the "+1?" button shows the RSVP form', async () => {
+    localStorage.setItem('my_events', JSON.stringify({ 'evt-1': { 'r1': 'tok' } }));
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    const btn = await screen.findByRole('button', { name: /Bringing a \+1/ });
+    await fireEvent.click(btn);
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeInTheDocument();
+  });
+
+  it('clicking "+1?" resets the form: name is empty and Going is selected', async () => {
+    localStorage.setItem('my_events', JSON.stringify({ 'evt-1': { 'r1': 'tok' } }));
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await screen.findByRole('button', { name: /Bringing a \+1/ });
+    // Drain onMount's promise chain (fetch → attendeeName = 'Alice') before clicking,
+    // matching real-world timing where onMount completes before any user interaction.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    await fireEvent.click(screen.getByRole('button', { name: /Bringing a \+1/ }));
+    expect(screen.getByPlaceholderText('Enter your name')).toHaveValue('');
+    expect(screen.getByRole('button', { name: 'Going' })).toHaveAttribute('aria-pressed', 'true');
+  });
+});
+
+describe('EventDetailPage — multi-user "Editing For" select', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  it('does not show the "Editing For" dropdown when only one user has RSVPed from this device', async () => {
+    localStorage.setItem('my_events', JSON.stringify({ 'evt-1': { 'r1': 'tok' } }));
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await new Promise(r => setTimeout(r, 0));
+    expect(screen.queryByLabelText('Editing For')).not.toBeInTheDocument();
+  });
+
+  it('shows the "Editing For" dropdown when two users have RSVPed from this device', async () => {
+    localStorage.setItem('my_events', JSON.stringify({ 'evt-1': { 'r1': 'tok1', 'r2': 'tok2' } }));
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok1' },
+      { id: 'r2', name: 'Bob', event_id: 'evt-1', status: 'maybe', guests: 0, token: 'tok2' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await new Promise(r => setTimeout(r, 0));
+    await waitFor(() => {
+      expect(screen.getByLabelText('Editing For')).toBeInTheDocument();
+    });
+  });
+
+  it('"Editing For" select contains both attendee names', async () => {
+    localStorage.setItem('my_events', JSON.stringify({ 'evt-1': { 'r1': 'tok1', 'r2': 'tok2' } }));
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok1' },
+      { id: 'r2', name: 'Bob', event_id: 'evt-1', status: 'maybe', guests: 0, token: 'tok2' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await new Promise(r => setTimeout(r, 0));
+    await waitFor(() => {
+      const select = screen.getByLabelText('Editing For');
+      expect(select).toBeInTheDocument();
+      expect(select.textContent).toContain('Alice');
+      expect(select.textContent).toContain('Bob');
+    });
+  });
+});
+
+describe('EventDetailPage — XSS safety', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  it('renders an attendee name with HTML payload as text, not as markup', async () => {
+    const xssName = '<script>alert(1)</script>';
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: xssName, event_id: 'evt-1', status: 'going', guests: 0, token: 'tok' },
+    ];
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await new Promise(r => setTimeout(r, 0));
+    await waitFor(() => {
+      // The list must be visible — toggle it
+      const toggleBtn = screen.queryByRole('button', { name: /Show Responses/ });
+      if (toggleBtn) toggleBtn.click();
+    });
+    // The raw string should appear as text content somewhere in the page
+    expect(document.body.textContent).toContain('<script>alert(1)</script>');
+    // No actual <script> element with that content should be present
+    const scripts = document.querySelectorAll('script');
+    scripts.forEach(s => {
+      expect(s.textContent).not.toContain('alert(1)');
+    });
+  });
+});
+
+describe('EventDetailPage — registration opens in future', () => {
+  it('shows a countdown when registration is not yet open', async () => {
+    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
+    const event: Event = { ...baseEvent, registration_opens_at: futureDate };
+
+    // Stub Intl.DurationFormat since it may not be available in all jsdom versions
+    const OrigIntl = globalThis.Intl;
+    (globalThis as any).Intl = {
+      ...OrigIntl,
+      DurationFormat: class {
+        format() {
+          return '1:00:00';
+        }
+      },
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+      } as Response),
+    );
+
+    render(EventDetailPage, { props: { data: buildData(event) } });
+
+    await waitFor(() => {
+      expect(screen.getByText(/Registration opens in/)).toBeInTheDocument();
+    });
+
+    (globalThis as any).Intl = OrigIntl;
+  });
+});

--- a/client/src/__tests__/routes/HomePage.test.ts
+++ b/client/src/__tests__/routes/HomePage.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, cleanup } from '@testing-library/svelte';
+import HomePage from '../../routes/+page.svelte';
+
+afterEach(cleanup);
+
+beforeEach(() => {
+  vi.useFakeTimers();
+});
+
+afterEach(() => {
+  vi.useRealTimers();
+});
+
+describe('Home page', () => {
+  it('renders a link to Create Event', () => {
+    render(HomePage);
+    expect(screen.getByRole('link', { name: 'Create Event' })).toHaveAttribute('href', '/create-event');
+  });
+
+  it('renders a link to View All Events', () => {
+    render(HomePage);
+    expect(screen.getByRole('link', { name: 'View All Events' })).toHaveAttribute('href', '/events');
+  });
+
+  it('renders a link to View My RSVPs', () => {
+    render(HomePage);
+    expect(screen.getByRole('link', { name: 'View My RSVPs' })).toHaveAttribute('href', '/my/rsvps');
+  });
+
+  it('sets the page title', () => {
+    render(HomePage);
+    // svelte:head title set by the component
+    expect(document.title).toBe('Welcome | Event RSVP');
+  });
+
+  it('renders the wave emoji', () => {
+    render(HomePage);
+    expect(document.body).toHaveTextContent('👋');
+  });
+});

--- a/client/src/__tests__/routes/MyRsvpsPage.test.ts
+++ b/client/src/__tests__/routes/MyRsvpsPage.test.ts
@@ -1,0 +1,234 @@
+import { afterEach, beforeEach, describe, it, expect, vi } from 'vitest';
+import { render, screen, waitFor, cleanup } from '@testing-library/svelte';
+import MyRsvpsPage from '../../routes/my/rsvps/+page.svelte';
+
+afterEach(() => {
+  cleanup();
+  vi.unstubAllGlobals();
+  localStorage.clear();
+});
+
+describe('My RSVPs page', () => {
+  it('shows loading indicator initially', () => {
+    vi.stubGlobal('fetch', vi.fn(() => new Promise(() => {})));
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'rsvp-1': 'tok' } }),
+    );
+    render(MyRsvpsPage);
+    expect(screen.getByText('Loading...')).toBeInTheDocument();
+  });
+
+  it('shows empty state when no RSVPs are stored in localStorage', async () => {
+    // No my_events key → getMyRsvps returns [] → onMount exits early
+    render(MyRsvpsPage);
+    await waitFor(() => {
+      expect(
+        screen.getByText("You haven't RSVP'd to any events"),
+      ).toBeInTheDocument();
+    });
+  });
+
+  it('sets the page title', () => {
+    render(MyRsvpsPage);
+    expect(document.title).toBe('My RSVPs | Event RSVP');
+  });
+
+  it('shows event cards after successful fetch', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'rsvp-1': 'tok' } }),
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          rsvps: [
+            {
+              event: {
+                id: 'evt-1',
+                name: 'Board Game Night',
+                date: '2024-06-15',
+                start_time: '19:00',
+                end_time: '22:00',
+                location: 'The Pub',
+                max_attendees: 10,
+              },
+              yourStatus: 'going',
+              attendeeName: null,
+            },
+          ],
+        }),
+      } as Response),
+    );
+
+    render(MyRsvpsPage);
+
+    await waitFor(() => {
+      expect(screen.getByText('Board Game Night')).toBeInTheDocument();
+    });
+    expect(screen.getByText('Going')).toBeInTheDocument();
+  });
+
+  it('shows the group heading for events', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'rsvp-1': 'tok' } }),
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          rsvps: [
+            {
+              event: {
+                id: 'evt-1',
+                name: 'Quiz Night',
+                date: '2024-06-15',
+                start_time: '19:00',
+                end_time: '21:00',
+                location: 'The Bar',
+                max_attendees: 20,
+              },
+              yourStatus: 'maybe',
+              attendeeName: null,
+            },
+          ],
+        }),
+      } as Response),
+    );
+
+    render(MyRsvpsPage);
+
+    await waitFor(() => {
+      expect(screen.getByText('Events you have responded to')).toBeInTheDocument();
+    });
+  });
+
+  it('shows per-attendee status badges for group RSVPs', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'rsvp-1': 'tok', 'rsvp-2': 'tok2' } }),
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          rsvps: [
+            {
+              event: {
+                id: 'evt-1',
+                name: 'Party',
+                date: '2024-07-04',
+                start_time: '20:00',
+                end_time: '23:00',
+                location: 'HQ',
+                max_attendees: 50,
+              },
+              yourStatus: 'going',
+              attendeeName: 'Alice',
+            },
+            {
+              event: {
+                id: 'evt-1',
+                name: 'Party',
+                date: '2024-07-04',
+                start_time: '20:00',
+                end_time: '23:00',
+                location: 'HQ',
+                max_attendees: 50,
+              },
+              yourStatus: 'maybe',
+              attendeeName: 'Bob',
+            },
+          ],
+        }),
+      } as Response),
+    );
+
+    render(MyRsvpsPage);
+
+    await waitFor(() => {
+      expect(screen.getByText(/Alice: Going/i)).toBeInTheDocument();
+      expect(screen.getByText(/Bob: Maybe/i)).toBeInTheDocument();
+    });
+  });
+
+  it('groups events into Upcoming and Past sections', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-past': { 'r1': 'tok' }, 'evt-future': { 'r2': 'tok2' } }),
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          rsvps: [
+            {
+              event: { id: 'evt-past', name: 'Past Event', date: '2000-01-01', start_time: '18:00', end_time: '22:00', location: 'Old Venue', max_attendees: 10 },
+              yourStatus: 'going',
+              attendeeName: null,
+            },
+            {
+              event: { id: 'evt-future', name: 'Future Event', date: '2099-01-01', start_time: '18:00', end_time: '22:00', location: 'New Venue', max_attendees: 10 },
+              yourStatus: 'going',
+              attendeeName: null,
+            },
+          ],
+        }),
+      } as Response),
+    );
+
+    render(MyRsvpsPage);
+
+    await waitFor(() => {
+      expect(screen.getByText('Upcoming Events')).toBeInTheDocument();
+      expect(screen.getByText('Past Events')).toBeInTheDocument();
+      expect(screen.getByText('Future Event')).toBeInTheDocument();
+      expect(screen.getByText('Past Event')).toBeInTheDocument();
+    });
+  });
+
+  it('shows "Going" status for a going RSVP (waitlist is not computed in this page)', async () => {
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'rsvp-1': 'tok' } }),
+    );
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: true,
+        status: 200,
+        json: async () => ({
+          rsvps: [
+            {
+              event: { id: 'evt-1', name: 'Full Event', date: '2099-12-25', start_time: '18:00', end_time: '22:00', location: 'Venue', max_attendees: 1 },
+              yourStatus: 'going',
+              attendeeName: null,
+            },
+          ],
+        }),
+      } as Response),
+    );
+
+    render(MyRsvpsPage);
+
+    await waitFor(() => {
+      // My RSVPs page shows the server-side yourStatus; it does not compute waitlist
+      expect(screen.getByText('Going')).toBeInTheDocument();
+    });
+  });
+});

--- a/client/vitest.config.ts
+++ b/client/vitest.config.ts
@@ -3,6 +3,9 @@ import { svelte } from '@sveltejs/vite-plugin-svelte';
 
 export default defineConfig({
   plugins: [svelte({ hot: false })],
+  resolve: {
+    conditions: ['browser'],
+  },
   test: {
     environment: 'jsdom',
     environmentOptions: {
@@ -16,6 +19,7 @@ export default defineConfig({
       $lib: '/src/lib',
       '$app/environment': '/src/__mocks__/app-environment.ts',
       '$app/stores': '/src/__mocks__/app-stores.ts',
+      '$app/navigation': '/src/__mocks__/app-navigation.ts',
     },
   },
 });


### PR DESCRIPTION
Add component- and page-level tests that render Svelte components in jsdom via
@testing-library/svelte.

- vitest.config: add the browser resolve condition and a $app/navigation mock so
  components that import it render under test
- Components: AttendeeList (going/waitlist split, aria, XSS-rendered-as-text),
  PollWidget (voting/results/sorting, XSS), RSVPForm, Header, Footer, MapLink
- Pages: EventDetailPage (RSVP form visibility, waitlist, admin view, +1,
  multi-user "Editing For" select, XSS, registration countdown), MyRsvpsPage
  (grouping, waitlist pin), HomePage, AdminLoginPage

One test characterizes a known crash: rendering EventDetailPage with a not-found
(null) event throws, because the page dereferences event fields without a null
guard.
