### PR TITLE
Add end-to-end tests with Playwright

### DIFF
--- a/client/.gitignore
+++ b/client/.gitignore
@@ -22,3 +22,7 @@ Thumbs.db
 # Vite
 vite.config.js.timestamp-*
 vite.config.ts.timestamp-*
+
+# Playwright
+test-results/
+playwright-report/

--- a/client/README.md
+++ b/client/README.md
@@ -36,3 +36,17 @@ npm run build
 You can preview the production build with `npm run preview`.
 
 > To deploy your app, you may need to install an [adapter](https://svelte.dev/docs/kit/adapters) for your target environment.
+
+## End-to-end tests
+
+End-to-end tests run with [Playwright](https://playwright.dev) against the real
+app. The Playwright config starts the API server (in-memory SQLite) and the
+SvelteKit dev server automatically before the tests.
+
+```sh
+yarn playwright install chromium   # one-time: install the browser
+yarn test:e2e                       # run the suite
+yarn test:e2e:ui                    # interactive UI mode
+```
+
+Specs live in `e2e/`.

--- a/client/e2e/admin-attendee-delete.spec.ts
+++ b/client/e2e/admin-attendee-delete.spec.ts
@@ -1,0 +1,69 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+async function createEvent(request: any) {
+  const res = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'Attendee Delete Test Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue',
+    },
+  });
+  return ((await res.json()).event.id) as string;
+}
+
+test.describe('Admin — delete attendee', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('credentials', 'e2eadmin:e2epass');
+    });
+    page.on('dialog', (dialog) => dialog.accept());
+  });
+
+  test('admin deletes attendee: name disappears and toast is shown', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+
+    const rsvpRes = await request.post(`${API}/events/${eventId}/rsvp`, {
+      data: { name: 'Deletable Alice', status: 'going' },
+    });
+    expect(rsvpRes.ok()).toBeTruthy();
+
+    await page.goto(`/events/${eventId}`);
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+    await expect(page.getByText('Deletable Alice')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete attendee' }).first().click();
+
+    await expect(page.getByText('Attendee deleted!')).toBeVisible();
+    await expect(page.getByText('Deletable Alice')).not.toBeVisible({ timeout: 5000 });
+  });
+
+  test('admin deletes one attendee out of two: other attendee remains', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+
+    await request.post(`${API}/events/${eventId}/rsvp`, {
+      data: { name: 'Keep Me', status: 'going' },
+    });
+    await request.post(`${API}/events/${eventId}/rsvp`, {
+      data: { name: 'Delete Me', status: 'going' },
+    });
+
+    await page.goto(`/events/${eventId}`);
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+    await expect(page.getByText('Delete Me')).toBeVisible();
+    await expect(page.getByText('Keep Me')).toBeVisible();
+
+    // Delete the first attendee in the list
+    const deleteButtons = page.getByRole('button', { name: 'Delete attendee' });
+    await deleteButtons.first().click();
+
+    await expect(page.getByText('Attendee deleted!')).toBeVisible();
+    // Exactly one attendee should remain
+    await expect(page.getByRole('button', { name: 'Delete attendee' })).toHaveCount(1);
+  });
+});

--- a/client/e2e/admin-create-event.spec.ts
+++ b/client/e2e/admin-create-event.spec.ts
@@ -1,0 +1,43 @@
+import { expect, test } from '@playwright/test';
+
+// Log in before each admin test by presetting localStorage credentials
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('credentials', 'e2eadmin:e2epass');
+  });
+  // Auto-accept all browser dialogs (the form shows alerts for success/errors)
+  page.on('dialog', (dialog) => dialog.accept());
+});
+
+test.describe('Admin — create event', () => {
+  test('creates an event via the form and shows the event link', async ({ page }) => {
+    await page.goto('/create-event');
+
+    // Wait for the auth check to complete before filling the form
+    await expect(page.getByRole('heading', { name: 'Create Event' })).toBeVisible();
+
+    await page.fill('input[name="name"]', 'Playwright Party');
+    await page.fill('input[name="date"]', '2099-06-15');
+    await page.fill('input[name="startTime"]', '19:00');
+    await page.fill('input[name="endTime"]', '23:00');
+    await page.fill('input[name="maxAttendees"]', '50');
+    await page.fill('input[name="location"]', 'Playwright HQ');
+
+    await page.click('button[type=submit]');
+
+    // After the alert is dismissed, the page shows a "View Event" link
+    await expect(page.getByRole('link', { name: 'View Event' })).toBeVisible({ timeout: 10000 });
+  });
+
+  test('shows an error when required fields are missing', async ({ page }) => {
+    await page.goto('/create-event');
+    await expect(page.getByRole('heading', { name: 'Create Event' })).toBeVisible();
+
+    // Submit with only name filled in — JS validation fires an alert and returns early
+    await page.fill('input[name="name"]', 'Incomplete Event');
+    await page.click('button[type=submit]');
+
+    // The page stays at /create-event after the alert is dismissed
+    await expect(page).toHaveURL('/create-event');
+  });
+});

--- a/client/e2e/admin-events.spec.ts
+++ b/client/e2e/admin-events.spec.ts
@@ -1,0 +1,80 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+async function createEvent(request: any) {
+  const res = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'Admin Events Test Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue',
+    },
+  });
+  return ((await res.json()).event.id) as string;
+}
+
+test.describe('Admin — events list', () => {
+  test.beforeEach(async ({ request }) => {
+    const res = await request.get(`${API}/admin/events`, { headers: { Authorization: AUTH } });
+    const { events } = await res.json();
+    for (const event of events) {
+      await request.delete(`${API}/admin/events/${event.id}`, { headers: { Authorization: AUTH } });
+    }
+  });
+
+  test('shows unauthorized message when not logged in', async ({ page }) => {
+    await page.goto('/events');
+    await expect(page.getByText(/unauthorized/i)).toBeVisible();
+  });
+
+  test('shows the events list when logged in', async ({ page, request }) => {
+    await createEvent(request);
+    await page.addInitScript(() => {
+      localStorage.setItem('credentials', 'e2eadmin:e2epass');
+    });
+    await page.goto('/events');
+    await expect(page.getByText('Admin Events Test Event')).toBeVisible();
+  });
+
+  test('deletes an event and removes it from the list', async ({ page, request }) => {
+    await createEvent(request);
+    await page.addInitScript(() => {
+      localStorage.setItem('credentials', 'e2eadmin:e2epass');
+    });
+    page.on('dialog', (dialog) => dialog.accept());
+    await page.goto('/events');
+    await expect(page.getByText('Admin Events Test Event')).toBeVisible();
+
+    await page.getByRole('button', { name: 'Delete event' }).first().click();
+    await expect(page.getByText('Admin Events Test Event')).not.toBeVisible({ timeout: 5000 });
+  });
+});
+
+test.describe('Admin — edit event', () => {
+  test.beforeEach(async ({ page }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('credentials', 'e2eadmin:e2epass');
+    });
+  });
+
+  test('can edit an event name', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}/edit`);
+    await expect(page.getByRole('heading', { name: 'Edit Event' })).toBeVisible();
+    await page.locator('#name').fill('Updated Event Name');
+    await page.click('button[type=submit]');
+    await page.waitForURL(`/events/${eventId}`);
+    await expect(page.getByText('Updated Event Name').first()).toBeVisible();
+  });
+});
+
+test.describe('Admin — auth guard', () => {
+  test('navigating to /create-event without credentials shows unauthorized state', async ({ page }) => {
+    await page.goto('/create-event');
+    await expect(page.getByText(/not authorized/i)).toBeVisible();
+  });
+});

--- a/client/e2e/admin-login.spec.ts
+++ b/client/e2e/admin-login.spec.ts
@@ -1,0 +1,21 @@
+import { expect, test } from '@playwright/test';
+
+test.describe('Admin login', () => {
+  test('redirects to /events on valid credentials', async ({ page }) => {
+    await page.goto('/admin/login');
+    await page.fill('#name', 'e2eadmin');
+    await page.fill('#password', 'e2epass');
+    await page.click('button[type=submit]');
+    await page.waitForURL('/events');
+    expect(page.url()).toContain('/events');
+  });
+
+  test('shows error message for wrong credentials', async ({ page }) => {
+    await page.goto('/admin/login');
+    await page.fill('#name', 'e2eadmin');
+    await page.fill('#password', 'wrongpass');
+    await page.click('button[type=submit]');
+    await expect(page.getByText('Invalid username or password')).toBeVisible();
+    expect(page.url()).toContain('/admin/login');
+  });
+});

--- a/client/e2e/capacity-and-misc.spec.ts
+++ b/client/e2e/capacity-and-misc.spec.ts
@@ -1,0 +1,213 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+test.describe('Capacity changes', () => {
+  test('expanding maxAttendees removes waitlist status for previously waitlisted user', async ({
+    page,
+    request,
+    browser,
+  }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Capacity Expand Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+        maxAttendees: 1,
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    // User 1 fills the single spot
+    await page.goto(`/events/${eventId}`);
+    await page.fill('#attendeeName', 'First User');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // User 2 ends up on waitlist
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto(`/events/${eventId}`);
+    await page2.fill('#attendeeName', 'Second User');
+    await page2.click('button[type=submit]:has-text("Submit")');
+    await expect(page2.getByText('Your response was saved!')).toBeVisible();
+    await expect(page2.getByText(/Waitlist/i)).toBeVisible();
+
+    // Admin expands capacity to 2
+    await page.addInitScript(() => {
+      localStorage.setItem('credentials', 'e2eadmin:e2epass');
+    });
+    await request.patch(`${API}/admin/events/${eventId}`, {
+      headers: { Authorization: AUTH },
+      data: { maxAttendees: 2 },
+    });
+
+    // After reload, User 2 should no longer be on the waitlist
+    await page2.reload();
+    await expect(page2.getByText(/Waitlist/i)).not.toBeVisible({ timeout: 5000 });
+    await expect(page2.getByText('Going', { exact: true })).toBeVisible();
+
+    await ctx2.close();
+  });
+
+  test('shrinking maxAttendees below current count puts later RSVPs on waitlist', async ({
+    page,
+    request,
+    browser,
+  }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Capacity Shrink Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+        maxAttendees: 3,
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    // Three users all RSVP as going
+    await page.goto(`/events/${eventId}`);
+    await page.fill('#attendeeName', 'User One');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto(`/events/${eventId}`);
+    await page2.fill('#attendeeName', 'User Two');
+    await page2.click('button[type=submit]:has-text("Submit")');
+    await expect(page2.getByText('Your response was saved!')).toBeVisible();
+    await expect(page2.getByText('Going', { exact: true })).toBeVisible();
+
+    const ctx3 = await browser.newContext();
+    const page3 = await ctx3.newPage();
+    await page3.goto(`/events/${eventId}`);
+    await page3.fill('#attendeeName', 'User Three');
+    await page3.click('button[type=submit]:has-text("Submit")');
+    await expect(page3.getByText('Your response was saved!')).toBeVisible();
+    await expect(page3.getByText('Going', { exact: true })).toBeVisible();
+
+    // Admin shrinks capacity to 1
+    await request.patch(`${API}/admin/events/${eventId}`, {
+      headers: { Authorization: AUTH },
+      data: { maxAttendees: 1 },
+    });
+
+    // After reload, users 2 and 3 should be on the waitlist
+    await page2.reload();
+    await expect(page2.getByText(/Waitlist/i)).toBeVisible({ timeout: 5000 });
+
+    await page3.reload();
+    await expect(page3.getByText(/Waitlist/i)).toBeVisible({ timeout: 5000 });
+
+    await ctx2.close();
+    await ctx3.close();
+  });
+});
+
+test.describe('Group RSVP attendee list', () => {
+  test('both Alice and Bob appear in attendee list after group RSVP', async ({ page, request }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Group RSVP Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    await page.goto(`/events/${eventId}`);
+
+    // First RSVP as Alice
+    await page.fill('#attendeeName', 'Alice');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // Add +1 as Bob
+    await page.getByRole('button', { name: /Bringing a \+1/i }).click();
+    await page.fill('#attendeeName', 'Bob');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // Open attendee list
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+    await expect(page.getByText('Alice')).toBeVisible();
+    await expect(page.getByText('Bob')).toBeVisible();
+  });
+});
+
+test.describe('Past event grouping', () => {
+  test('event with past date appears under Past Events in admin /events list', async ({
+    page,
+    request,
+  }) => {
+    await page.addInitScript(() => {
+      localStorage.setItem('credentials', 'e2eadmin:e2epass');
+    });
+
+    await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Old Time Event',
+        date: '2000-01-01',
+        startTime: '12:00',
+        endTime: '14:00',
+        location: 'History',
+      },
+    });
+
+    await page.goto('/events');
+    await expect(page.getByText('Past Events')).toBeVisible();
+    await expect(page.getByText('Old Time Event')).toBeVisible();
+  });
+});
+
+test.describe('404 page', () => {
+  test('navigating to a non-existent route shows 404 Not Found', async ({ page }) => {
+    await page.goto('/not-a-page');
+    await expect(page.getByText('404')).toBeVisible();
+    await expect(page.getByText('Not Found')).toBeVisible();
+  });
+});
+
+test.describe('XSS smoke test', () => {
+  test('RSVP name with script tag renders as text, not injected HTML', async ({ page, request }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'XSS Test Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    const xssName = '<script>window.__xss=1</script>Mallory';
+
+    await page.goto(`/events/${eventId}`);
+    await page.fill('#attendeeName', xssName);
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+
+    // The raw text (including angle brackets) should appear in the DOM as text
+    await expect(page.getByText(/Mallory/)).toBeVisible();
+
+    // The script tag must NOT have been injected — window.__xss should be undefined
+    const injected = await page.evaluate(() => (window as any).__xss);
+    expect(injected).toBeUndefined();
+  });
+});

--- a/client/e2e/my-rsvps.spec.ts
+++ b/client/e2e/my-rsvps.spec.ts
@@ -1,0 +1,103 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+async function createEvent(request: any) {
+  const res = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'My RSVPs Test Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue',
+    },
+  });
+  return ((await res.json()).event.id) as string;
+}
+
+test.describe('My RSVPs page', () => {
+  test('shows empty state when user has no stored RSVPs', async ({ page }) => {
+    await page.goto('/my/rsvps');
+    await expect(page.getByText("You haven't RSVP'd to any events")).toBeVisible();
+  });
+
+  test('shows the event after RSVPing to it', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    await page.fill('#attendeeName', 'My RSVPs User');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    await page.goto('/my/rsvps');
+    await expect(page.getByText('My RSVPs Test Event')).toBeVisible();
+    await expect(page.getByText(/Going/i)).toBeVisible();
+  });
+
+  test('shows group attendee badges when two RSVPs are stored for the same event', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+
+    // First RSVP
+    await page.goto(`/events/${eventId}`);
+    await page.fill('#attendeeName', 'Alice');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // Add a +1 via the "Bringing a +1?" button so a second RSVP is stored
+    await page.getByRole('button', { name: /Bringing a \+1/i }).click();
+    await page.fill('#attendeeName', 'Bob');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    await page.goto('/my/rsvps');
+    // Both attendee names should be visible as per-attendee badges
+    await expect(page.getByText(/Alice/)).toBeVisible();
+    await expect(page.getByText(/Bob/)).toBeVisible();
+  });
+
+  test('shows empty state after RSVPed event is deleted', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    await page.fill('#attendeeName', 'Stale RSVP User');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    await request.delete(`${API}/admin/events/${eventId}`, {
+      headers: { Authorization: AUTH },
+    });
+
+    await page.goto('/my/rsvps');
+    await expect(page.getByText("You haven't RSVP'd to any events")).toBeVisible();
+  });
+
+  test('shows empty state after admin deletes the individual RSVP server-side', async ({
+    page,
+    request,
+  }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    await page.fill('#attendeeName', 'Server-Deleted User');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // Fetch the RSVP id from the event detail page's stored localStorage
+    const rsvpId = await page.evaluate((eId: string) => {
+      const stored = JSON.parse(localStorage.getItem('my_events') || '{}');
+      return Object.keys(stored[eId] || {})[0] ?? null;
+    }, eventId);
+    expect(rsvpId).toBeTruthy();
+
+    // Admin deletes the individual RSVP (not the whole event)
+    const delRes = await request.delete(`${API}/admin/events/rsvp/${rsvpId}`, {
+      headers: { Authorization: AUTH },
+    });
+    expect(delRes.ok()).toBeTruthy();
+
+    await page.goto('/my/rsvps');
+    await expect(page.getByText("You haven't RSVP'd to any events")).toBeVisible();
+  });
+});

--- a/client/e2e/poll-lifecycle.spec.ts
+++ b/client/e2e/poll-lifecycle.spec.ts
@@ -1,0 +1,174 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+async function setupEventWithRsvpAndPoll(request: any) {
+  const eventRes = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'Poll Lifecycle Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue',
+    },
+  });
+  const eventId = (await eventRes.json()).event.id as string;
+
+  const rsvpRes = await request.post(`${API}/events/${eventId}/rsvp`, {
+    data: { name: 'Poll Tester', status: 'going' },
+  });
+  const { rsvp } = await rsvpRes.json();
+
+  const pollRes = await request.post(`${API}/admin/events/${eventId}/poll`, {
+    headers: { Authorization: AUTH },
+    data: {
+      title: 'Favourite Snack',
+      options: [
+        { name: 'Chips', url: 'https://example.com/chips' },
+        { name: 'Pretzels', url: 'https://example.com/pretzels' },
+      ],
+    },
+  });
+  const poll = (await pollRes.json()).poll;
+  const options = poll.options as { id: string; name: string; url: string }[];
+
+  return {
+    eventId,
+    rsvpId: rsvp.id as string,
+    token: rsvp.token as string,
+    pollId: poll.id as string,
+    options,
+  };
+}
+
+test.describe('Poll lifecycle', () => {
+  test('admin closes poll: voting disabled, results still visible', async ({ page, request }) => {
+    const { eventId, rsvpId, token, pollId } = await setupEventWithRsvpAndPoll(request);
+
+    await page.addInitScript(
+      ({ eventId, rsvpId, token }: { eventId: string; rsvpId: string; token: string }) => {
+        localStorage.setItem('my_events', JSON.stringify({ [eventId]: { [rsvpId]: token } }));
+      },
+      { eventId, rsvpId, token }
+    );
+
+    // Cast a vote before closing
+    await request.post(`${API}/polls/${pollId}/vote`, {
+      data: { rsvpId, token, optionIds: [] },
+    });
+
+    // Admin closes the poll
+    const closeRes = await request.patch(`${API}/admin/polls/${pollId}/close`, {
+      headers: { Authorization: AUTH },
+    });
+    expect(closeRes.ok()).toBeTruthy();
+
+    await page.goto(`/events/${eventId}`);
+
+    // Vote checkboxes should be gone (poll is closed)
+    await expect(page.locator('input[type="checkbox"]')).toHaveCount(0);
+
+    // Poll options (Chips, Pretzels) should still be visible
+    await expect(page.getByText('Chips')).toBeVisible();
+    await expect(page.getByText('Pretzels')).toBeVisible();
+  });
+
+  test('admin reopens poll: user can change vote', async ({ page, request }) => {
+    const { eventId, rsvpId, token, pollId } = await setupEventWithRsvpAndPoll(request);
+
+    await page.addInitScript(
+      ({ eventId, rsvpId, token }: { eventId: string; rsvpId: string; token: string }) => {
+        localStorage.setItem('my_events', JSON.stringify({ [eventId]: { [rsvpId]: token } }));
+      },
+      { eventId, rsvpId, token }
+    );
+
+    // Close then reopen
+    await request.patch(`${API}/admin/polls/${pollId}/close`, { headers: { Authorization: AUTH } });
+    const reopenRes = await request.patch(`${API}/admin/polls/${pollId}/reopen`, {
+      headers: { Authorization: AUTH },
+    });
+    expect(reopenRes.ok()).toBeTruthy();
+
+    await page.goto(`/events/${eventId}`);
+
+    // Vote for Chips
+    const chipsItem = page.locator('li').filter({ hasText: 'Chips' });
+    await chipsItem.locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+    await expect(chipsItem.getByText('1 vote')).toBeVisible();
+
+    // Change vote to Pretzels
+    await chipsItem.locator('input[type="checkbox"]').uncheck();
+    const pretzelsItem = page.locator('li').filter({ hasText: 'Pretzels' });
+    await pretzelsItem.locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+    await expect(chipsItem.getByText('0 votes')).toBeVisible();
+    await expect(pretzelsItem.getByText('1 vote')).toBeVisible();
+  });
+
+  test('admin adds a third option: existing votes preserved and user can vote for new option', async ({
+    page,
+    request,
+  }) => {
+    const { eventId, rsvpId, token, pollId, options } = await setupEventWithRsvpAndPoll(request);
+
+    await page.addInitScript(
+      ({ eventId, rsvpId, token }: { eventId: string; rsvpId: string; token: string }) => {
+        localStorage.setItem('my_events', JSON.stringify({ [eventId]: { [rsvpId]: token } }));
+      },
+      { eventId, rsvpId, token }
+    );
+
+    // Vote for Chips first
+    await page.goto(`/events/${eventId}`);
+    await page.locator('li').filter({ hasText: 'Chips' }).locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+
+    // Admin adds a third option via PATCH — include existing option IDs so votes are preserved
+    const updateRes = await request.patch(`${API}/admin/polls/${pollId}`, {
+      headers: { Authorization: AUTH },
+      data: {
+        title: 'Favourite Snack',
+        options: [
+          ...options.map((o) => ({ id: o.id, name: o.name, url: o.url })),
+          { name: 'Popcorn', url: 'https://example.com/popcorn' },
+        ],
+      },
+    });
+    expect(updateRes.ok()).toBeTruthy();
+
+    await page.reload();
+
+    // Chips vote should still be there
+    await expect(page.locator('li').filter({ hasText: 'Chips' }).getByText('1 vote')).toBeVisible();
+
+    // New option should be present and voteable
+    const popcornItem = page.locator('li').filter({ hasText: 'Popcorn' });
+    await expect(popcornItem).toBeVisible();
+    await popcornItem.locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+    await expect(popcornItem.getByText('1 vote')).toBeVisible();
+  });
+
+  test('admin deletes poll: widget disappears from event page', async ({ page, request }) => {
+    const { eventId, pollId } = await setupEventWithRsvpAndPoll(request);
+
+    await page.goto(`/events/${eventId}`);
+    await expect(page.getByText('Favourite Snack')).toBeVisible();
+
+    const deleteRes = await request.delete(`${API}/admin/polls/${pollId}`, {
+      headers: { Authorization: AUTH },
+    });
+    expect(deleteRes.ok()).toBeTruthy();
+
+    await page.reload();
+    await expect(page.getByText('Favourite Snack')).not.toBeVisible({ timeout: 5000 });
+  });
+});

--- a/client/e2e/poll-voting.spec.ts
+++ b/client/e2e/poll-voting.spec.ts
@@ -1,0 +1,64 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+test.describe('Poll voting', () => {
+  test('can vote on a poll option and see the vote count update', async ({ page, request }) => {
+    const eventRes = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Poll Voting Test Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+      },
+    });
+    const eventId = (await eventRes.json()).event.id as string;
+
+    const rsvpRes = await request.post(`${API}/events/${eventId}/rsvp`, {
+      data: { name: 'Poll Voter', status: 'going' },
+    });
+    const { rsvp } = await rsvpRes.json();
+    const rsvpId = rsvp.id as string;
+    const token = rsvp.token as string;
+
+    await request.post(`${API}/admin/events/${eventId}/poll`, {
+      headers: { Authorization: AUTH },
+      data: {
+        title: 'Script Vote',
+        options: [
+          { name: 'Script A', url: 'https://example.com/a' },
+          { name: 'Script B', url: 'https://example.com/b' },
+        ],
+      },
+    });
+
+    await page.addInitScript(
+      ({ eventId, rsvpId, token }: { eventId: string; rsvpId: string; token: string }) => {
+        localStorage.setItem('my_events', JSON.stringify({ [eventId]: { [rsvpId]: token } }));
+      },
+      { eventId, rsvpId, token }
+    );
+
+    await page.goto(`/events/${eventId}`);
+
+    const optionA = page.locator('li').filter({ hasText: 'Script A' });
+    const optionB = page.locator('li').filter({ hasText: 'Script B' });
+
+    // Vote for Script A
+    await optionA.locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+    await expect(optionA.getByText('1 vote')).toBeVisible();
+
+    // Switch vote to Script B
+    await optionA.locator('input[type="checkbox"]').uncheck();
+    await optionB.locator('input[type="checkbox"]').check();
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+    await expect(optionA.getByText('0 votes')).toBeVisible();
+    await expect(optionB.getByText('1 vote')).toBeVisible();
+  });
+});

--- a/client/e2e/rsvp-flow.spec.ts
+++ b/client/e2e/rsvp-flow.spec.ts
@@ -1,0 +1,128 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+async function createEvent(request: any) {
+  const res = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'E2E Test Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue, Berlin',
+    },
+  });
+  const body = await res.json();
+  return body.event.id as string;
+}
+
+test.describe('RSVP flow', () => {
+  test('displays the event page with name and location', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+    await expect(page.getByText('E2E Test Event')).toBeVisible();
+    await expect(page.getByText('Test Venue, Berlin')).toBeVisible();
+  });
+
+  test('can submit an RSVP and see confirmation', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    await page.fill('#attendeeName', 'Test User');
+    await page.click('button[aria-pressed="false"]:has-text("Going")');
+    await page.click('button[type=submit]:has-text("Submit")');
+
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+  });
+
+  test('shows going status after submitting', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    await page.fill('#attendeeName', 'Alice');
+    await page.click('button[type=submit]:has-text("Submit")');
+
+    await expect(page.getByText(/marked as/i)).toBeVisible();
+    await expect(page.getByText(/Going/i)).toBeVisible();
+  });
+
+  test('attendee appears in the attendee list after RSVP', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    await page.fill('#attendeeName', 'Visible User');
+    await page.click('button[type=submit]:has-text("Submit")');
+
+    // Wait for the success toast, then open the collapsible attendee list
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+
+    await expect(page.getByText('Visible User')).toBeVisible();
+  });
+
+  test('crashes with a 500 for a non-existent event (BUG: no null guard)', async ({ page }) => {
+    // BUG: the event page dereferences event.id during SSR, so a non-existent
+    // event id (the load function returns { event: null }) crashes the render
+    // with a 500 instead of showing a friendly "No Such Event was found!"
+    // message. The page should null-guard event before reading its fields.
+    const response = await page.goto('/events/no-such-event-id');
+    expect(response?.status()).toBe(500);
+    await expect(page.getByText('No Such Event was found!')).not.toBeVisible();
+  });
+
+  test('can edit an existing RSVP and change status to Maybe', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    // Initial RSVP as Going (default)
+    await page.fill('#attendeeName', 'Edit RSVP User');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // Reopen the form
+    await page.getByRole('button', { name: 'Edit' }).click();
+    await expect(page.getByRole('button', { name: 'Submit' })).toBeVisible();
+
+    // Change to Maybe and re-submit
+    await page.getByRole('button', { name: 'Maybe' }).click();
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // Status indicator now shows Maybe
+    await expect(page.getByText(/marked as/i)).toBeVisible();
+    await expect(page.getByText('Maybe')).toBeVisible();
+  });
+
+  test('shows Waitlist status when event is at capacity', async ({ page, request, browser }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Capacity Test Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue, Berlin',
+        maxAttendees: 1,
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    // User 1 fills the single available spot
+    await page.goto(`/events/${eventId}`);
+    await page.fill('#attendeeName', 'User One');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    // User 2 in a fresh browser context (fresh localStorage, different "device")
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto(`/events/${eventId}`);
+    await page2.fill('#attendeeName', 'User Two');
+    await page2.click('button[type=submit]:has-text("Submit")');
+    await expect(page2.getByText('Your response was saved!')).toBeVisible();
+    await expect(page2.getByText(/Waitlist/i)).toBeVisible();
+    await ctx2.close();
+  });
+});

--- a/client/package.json
+++ b/client/package.json
@@ -12,11 +12,14 @@
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
     "format": "prettier --write .",
-    "lint": "prettier --check . && eslint ."
+    "lint": "prettier --check . && eslint .",
+    "test:e2e": "playwright test",
+    "test:e2e:ui": "playwright test --ui"
   },
   "devDependencies": {
     "@eslint/compat": "^1.2.5",
     "@eslint/js": "^9.18.0",
+    "@playwright/test": "^1.60.0",
     "@sveltejs/adapter-auto": "^6.0.0",
     "@sveltejs/kit": "^2.22.0",
     "@sveltejs/vite-plugin-svelte": "^6.0.0",

--- a/client/playwright.config.ts
+++ b/client/playwright.config.ts
@@ -1,0 +1,43 @@
+import { defineConfig, devices } from '@playwright/test';
+
+export default defineConfig({
+  testDir: './e2e',
+  fullyParallel: false,
+  retries: 0,
+  workers: 1,
+  reporter: 'list',
+
+  use: {
+    baseURL: 'http://localhost:5173',
+    trace: 'on-first-retry',
+  },
+
+  projects: [
+    {
+      name: 'chromium',
+      use: { ...devices['Desktop Chrome'] },
+    },
+  ],
+
+  // Start both the API server and the SvelteKit dev server before tests run
+  webServer: [
+    {
+      command: 'yarn dev',
+      url: 'http://localhost:3000/ping',
+      reuseExistingServer: false,
+      cwd: '../server',
+      env: {
+        PORT: '3000',
+        SQLITE_DB_PATH: ':memory:',
+        ADMIN_USER: 'e2eadmin',
+        ADMIN_PASSWORD: 'e2epass',
+        NODE_ENV: 'test',
+      },
+    },
+    {
+      command: 'vite dev --port 5173',
+      url: 'http://localhost:5173',
+      reuseExistingServer: false,
+    },
+  ],
+});

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -911,6 +911,17 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@playwright/test@npm:^1.60.0":
+  version: 1.60.0
+  resolution: "@playwright/test@npm:1.60.0"
+  dependencies:
+    playwright: "npm:1.60.0"
+  bin:
+    playwright: cli.js
+  checksum: 10c0/86b06e6437933e741c7cd43f362024e857e7bc28a55fcbb0553ef55e01a2a403c64f4786868de8af86a6e303fe99e98a18a42ba19489f43ae122e457f9e2d189
+  languageName: node
+  linkType: hard
+
 "@polka/url@npm:^1.0.0-next.24":
   version: 1.0.0-next.29
   resolution: "@polka/url@npm:1.0.0-next.29"
@@ -1764,6 +1775,7 @@ __metadata:
   dependencies:
     "@eslint/compat": "npm:^1.2.5"
     "@eslint/js": "npm:^9.18.0"
+    "@playwright/test": "npm:^1.60.0"
     "@sveltejs/adapter-auto": "npm:^6.0.0"
     "@sveltejs/kit": "npm:^2.22.0"
     "@sveltejs/vite-plugin-svelte": "npm:^6.0.0"
@@ -2470,12 +2482,31 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fsevents@npm:2.3.2":
+  version: 2.3.2
+  resolution: "fsevents@npm:2.3.2"
+  dependencies:
+    node-gyp: "npm:latest"
+  checksum: 10c0/be78a3efa3e181cda3cf7a4637cb527bcebb0bd0ea0440105a3bb45b86f9245b307dc10a2507e8f4498a7d4ec349d1910f4d73e4d4495b16103106e07eee735b
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
 "fsevents@npm:~2.3.2, fsevents@npm:~2.3.3":
   version: 2.3.3
   resolution: "fsevents@npm:2.3.3"
   dependencies:
     node-gyp: "npm:latest"
   checksum: 10c0/a1f0c44595123ed717febbc478aa952e47adfc28e2092be66b8ab1635147254ca6cfe1df792a8997f22716d4cbafc73309899ff7bfac2ac3ad8cf2e4ecc3ec60
+  conditions: os=darwin
+  languageName: node
+  linkType: hard
+
+"fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>":
+  version: 2.3.2
+  resolution: "fsevents@patch:fsevents@npm%3A2.3.2#optional!builtin<compat/fsevents>::version=2.3.2&hash=df0bf1"
+  dependencies:
+    node-gyp: "npm:latest"
   conditions: os=darwin
   languageName: node
   linkType: hard
@@ -3328,6 +3359,30 @@ __metadata:
   version: 4.0.3
   resolution: "picomatch@npm:4.0.3"
   checksum: 10c0/9582c951e95eebee5434f59e426cddd228a7b97a0161a375aed4be244bd3fe8e3a31b846808ea14ef2c8a2527a6eeab7b3946a67d5979e81694654f939473ae2
+  languageName: node
+  linkType: hard
+
+"playwright-core@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright-core@npm:1.60.0"
+  bin:
+    playwright-core: cli.js
+  checksum: 10c0/99ccd43923b6e9355e0723b7fe221e6326efd4687f8dafff951313662aea11db51f542a9c2122c704c445fb9baae1c9ec9fa6f895126bbddd9fe92313f6942c9
+  languageName: node
+  linkType: hard
+
+"playwright@npm:1.60.0":
+  version: 1.60.0
+  resolution: "playwright@npm:1.60.0"
+  dependencies:
+    fsevents: "npm:2.3.2"
+    playwright-core: "npm:1.60.0"
+  dependenciesMeta:
+    fsevents:
+      optional: true
+  bin:
+    playwright: cli.js
+  checksum: 10c0/714ad76d85b4865d7e43c0012f9039800c1485373388973ed39d79339cee5ad467052d1e2f1eaeca107a1cb6e65342186a8578a4c3504853d84c3a691250d5db
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add Playwright E2E tests that drive the real app: the config boots the API
server (in-memory SQLite, NODE_ENV=test) and the SvelteKit dev server, then runs
chromium specs against them with a single worker.

- playwright.config.ts: a webServer for both the API server and the client,
  baseURL, and a chromium project
- Specs: admin login, event create/list/edit/delete, attendee delete, the RSVP
  flow (submit/edit/waitlist), polls (voting and lifecycle), capacity changes,
  group RSVP, the My RSVPs page, the route-level 404, and an XSS smoke test
- Add @playwright/test plus test:e2e / test:e2e:ui scripts, and ignore
  test-results/ and playwright-report/

The suite relies on the server's NODE_ENV=test rate-limiter gating (from the
server stack it builds on) so repeated requests don't hit the limit. One spec
characterizes a known bug: a non-existent event id crashes the page render with
a 500 instead of showing a not-found message.
