### PR TITLE
Add lottery selection mode for event seat allocation

### DIFF
--- a/client/e2e/lottery.spec.ts
+++ b/client/e2e/lottery.spec.ts
@@ -1,0 +1,173 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+// Log in as admin and auto-accept dialogs (the forms/draw use alerts + confirm).
+test.beforeEach(async ({ page }) => {
+  await page.addInitScript(() => {
+    localStorage.setItem('credentials', 'e2eadmin:e2epass');
+  });
+  page.on('dialog', (dialog) => dialog.accept());
+});
+
+test.describe('Lottery — create and draw', () => {
+  test('admin creates a lottery event via the form, then runs the draw', async ({ page, browser }) => {
+    // Create the event through the real form, choosing Lottery mode.
+    await page.goto('/create-event');
+    await expect(page.getByRole('heading', { name: 'Create Event' })).toBeVisible();
+    await page.fill('input[name="name"]', 'Lottery Night');
+    await page.fill('input[name="date"]', '2099-06-15');
+    await page.fill('input[name="startTime"]', '19:00');
+    await page.fill('input[name="endTime"]', '23:00');
+    await page.fill('input[name="maxAttendees"]', '10');
+    await page.fill('input[name="location"]', 'The Venue');
+    await page.selectOption('#selectionMode', 'lottery');
+    await page.click('button[type=submit]');
+
+    await page.getByRole('link', { name: 'View Event' }).click();
+
+    // Before the draw: the lottery banner and the admin draw button are shown.
+    await expect(page.getByText(/lottery event/i)).toBeVisible();
+    const drawButton = page.getByRole('button', { name: 'Run the draw' });
+    await expect(drawButton).toBeVisible();
+
+    // Two people sign up as going.
+    await page.fill('#attendeeName', 'Alice');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto(page.url());
+    await page2.fill('#attendeeName', 'Bob');
+    await page2.click('button[type=submit]:has-text("Submit")');
+    await expect(page2.getByText('Your response was saved!')).toBeVisible();
+    await ctx2.close();
+
+    // Admin runs the draw; the UI flips to the drawn state and the button disappears.
+    await drawButton.click();
+    await expect(page.getByText(/allocated by random draw/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Run the draw' })).toHaveCount(0);
+  });
+
+  test('hides the waitlist before the draw and reveals it afterwards', async ({ page, request, browser }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Lottery Seat Race',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+        maxAttendees: 1,
+        selectionMode: 'lottery',
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    // Two entrants for one seat.
+    await page.goto(`/events/${eventId}`);
+    await page.fill('#attendeeName', 'Alice');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    const ctx2 = await browser.newContext();
+    const page2 = await ctx2.newPage();
+    await page2.goto(`/events/${eventId}`);
+    await page2.fill('#attendeeName', 'Bob');
+    await page2.click('button[type=submit]:has-text("Submit")');
+    await expect(page2.getByText('Your response was saved!')).toBeVisible();
+    await ctx2.close();
+
+    // Before the draw: both entrants listed, no waitlist split.
+    await page.reload();
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+    const attendeeList = page.locator('#attendees-list');
+    await expect(attendeeList.getByText('In the draw')).toBeVisible();
+    await expect(attendeeList.getByText('Waitlist', { exact: true })).toHaveCount(0);
+    // The admin signed up while logged in, so their entry carries the priority
+    // badge (the client must send credentials on the sign-up for this to work).
+    await expect(attendeeList.getByText('Priority')).toBeVisible();
+
+    // After the draw: capacity applies, so one entrant is waitlisted.
+    await page.getByRole('button', { name: 'Run the draw' }).click();
+    await expect(page.getByText(/allocated by random draw/i)).toBeVisible();
+    await expect(attendeeList.getByText('Waitlist', { exact: true })).toBeVisible();
+    await expect(attendeeList.getByText('In the draw')).toHaveCount(0);
+  });
+
+  test('lets a non-admin sign up before registration_opens_at (the draw is the gate)', async ({ request, browser }) => {
+    // A lottery event with a registration window that has not opened yet. The
+    // server ignores registration_opens_at for lottery, so the client must too:
+    // a non-admin must be able to enter the draw, not be blocked by a countdown.
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Lottery Open Early',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+        maxAttendees: 10,
+        selectionMode: 'lottery',
+        registrationOpensAt: new Date(Date.now() + 60 * 60 * 1000).toISOString(),
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    // Visit as a non-admin (fresh context, no credentials).
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(`/events/${eventId}`);
+
+    // No "Registration opens in" countdown, and the sign-up actually goes through.
+    await expect(page.getByText(/Registration opens in/i)).toHaveCount(0);
+    await page.fill('#attendeeName', 'EarlyBird');
+    await page.click('button[type=submit]:has-text("Submit")');
+    await expect(page.getByText('Your response was saved!')).toBeVisible();
+
+    await ctx.close();
+  });
+
+  test('shows a priority badge and hides the draw button from non-admins', async ({ request, browser }) => {
+    const res = await request.post(`${API}/admin/create-event`, {
+      headers: { Authorization: AUTH },
+      data: {
+        name: 'Lottery Badge Event',
+        date: '2099-12-25',
+        startTime: '18:00',
+        endTime: '22:00',
+        location: 'Test Venue',
+        maxAttendees: 10,
+        selectionMode: 'lottery',
+      },
+    });
+    const eventId = (await res.json()).event.id as string;
+
+    // An admin-created RSVP is stamped with priority; a public one is not.
+    await request.post(`${API}/events/${eventId}/rsvp`, {
+      headers: { Authorization: AUTH },
+      data: { name: 'Captain', status: 'going' },
+    });
+    await request.post(`${API}/events/${eventId}/rsvp`, {
+      data: { name: 'Regular', status: 'going' },
+    });
+
+    // Visit as a non-admin (fresh context, no credentials).
+    const ctx = await browser.newContext();
+    const page = await ctx.newPage();
+    await page.goto(`/events/${eventId}`);
+
+    // The lottery banner is shown to everyone, but the draw button is admin-only.
+    await expect(page.getByText(/lottery event/i)).toBeVisible();
+    await expect(page.getByRole('button', { name: 'Run the draw' })).toHaveCount(0);
+
+    // The priority entrant carries a visible badge in the attendee list.
+    await page.getByRole('button', { name: /Show Responses/i }).click();
+    await expect(page.getByText('Captain')).toBeVisible();
+    await expect(page.getByText('Priority')).toBeVisible();
+
+    await ctx.close();
+  });
+});

--- a/client/e2e/lottery.spec.ts
+++ b/client/e2e/lottery.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -14,7 +15,7 @@ test.beforeEach(async ({ page }) => {
 test.describe('Lottery — create and draw', () => {
   test('admin creates a lottery event via the form, then runs the draw', async ({ page, browser }) => {
     // Create the event through the real form, choosing Lottery mode.
-    await page.goto('/create-event');
+    await gotoHydrated(page, '/create-event');
     await expect(page.getByRole('heading', { name: 'Create Event' })).toBeVisible();
     await page.fill('input[name="name"]', 'Lottery Night');
     await page.fill('input[name="date"]', '2099-06-15');
@@ -39,7 +40,7 @@ test.describe('Lottery — create and draw', () => {
 
     const ctx2 = await browser.newContext();
     const page2 = await ctx2.newPage();
-    await page2.goto(page.url());
+    await gotoHydrated(page2, page.url());
     await page2.fill('#attendeeName', 'Bob');
     await page2.click('button[type=submit]:has-text("Submit")');
     await expect(page2.getByText('Your response was saved!')).toBeVisible();
@@ -67,14 +68,14 @@ test.describe('Lottery — create and draw', () => {
     const eventId = (await res.json()).event.id as string;
 
     // Two entrants for one seat.
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.fill('#attendeeName', 'Alice');
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
 
     const ctx2 = await browser.newContext();
     const page2 = await ctx2.newPage();
-    await page2.goto(`/events/${eventId}`);
+    await gotoHydrated(page2, `/events/${eventId}`);
     await page2.fill('#attendeeName', 'Bob');
     await page2.click('button[type=submit]:has-text("Submit")');
     await expect(page2.getByText('Your response was saved!')).toBeVisible();
@@ -119,7 +120,7 @@ test.describe('Lottery — create and draw', () => {
     // Visit as a non-admin (fresh context, no credentials).
     const ctx = await browser.newContext();
     const page = await ctx.newPage();
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // No "Registration opens in" countdown, and the sign-up actually goes through.
     await expect(page.getByText(/Registration opens in/i)).toHaveCount(0);
@@ -157,7 +158,7 @@ test.describe('Lottery — create and draw', () => {
     // Visit as a non-admin (fresh context, no credentials).
     const ctx = await browser.newContext();
     const page = await ctx.newPage();
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // The lottery banner is shown to everyone, but the draw button is admin-only.
     await expect(page.getByText(/lottery event/i)).toBeVisible();

--- a/client/src/__tests__/components/AttendeeList.test.ts
+++ b/client/src/__tests__/components/AttendeeList.test.ts
@@ -58,6 +58,32 @@ describe('AttendeeList', () => {
     expect(screen.getByRole('button', { name: /Hide Responses/ })).toHaveAttribute('aria-expanded', 'true');
   });
 
+  it('shows a Priority badge for a lottery attendee with a positive priority_weight', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ name: 'Alice', priority_weight: 1 })], maxAttendees: 10, isLottery: true },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.getByText('Priority')).toBeInTheDocument();
+  });
+
+  it('does not show a Priority badge when priority_weight is zero or absent', async () => {
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ name: 'Alice', priority_weight: 0 })], maxAttendees: 10, isLottery: true },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+  });
+
+  it('does not show a Priority badge for a FIFO event even with a positive priority_weight', async () => {
+    // Admins are stamped a priority weight on every sign-up, including FIFO, where
+    // it has no effect — the badge must stay hidden so it does not mislead.
+    render(AttendeeList, {
+      props: { attendees: [makeRsvp({ name: 'Alice', priority_weight: 1 })], maxAttendees: 10, isLottery: false },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+    expect(screen.queryByText('Priority')).not.toBeInTheDocument();
+  });
+
   it('shows Going group header when going attendees are present', async () => {
     render(AttendeeList, {
       props: { attendees: [makeRsvp({ status: 'going' })], maxAttendees: 10 },
@@ -112,6 +138,35 @@ describe('AttendeeList', () => {
     render(AttendeeList, { props: { attendees, maxAttendees: 5 } });
     await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
     expect(screen.queryByText('Waitlist')).not.toBeInTheDocument();
+  });
+
+  describe('lottery (pre-draw)', () => {
+    const overSubscribed = [
+      makeRsvp({ id: 'r1', name: 'Alice', status: 'going' }),
+      makeRsvp({ id: 'r2', name: 'Bob', status: 'going' }),
+      makeRsvp({ id: 'r3', name: 'Charlie', status: 'going' }),
+    ];
+
+    it('does not show a Waitlist even when entrants exceed the seats', async () => {
+      render(AttendeeList, { props: { attendees: overSubscribed, maxAttendees: 2, lotteryPredraw: true } });
+      await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+      expect(screen.queryByText('Waitlist')).not.toBeInTheDocument();
+    });
+
+    it('lists every entrant (no slicing to capacity) under an "In the draw" header', async () => {
+      render(AttendeeList, { props: { attendees: overSubscribed, maxAttendees: 2, lotteryPredraw: true } });
+      await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+      expect(screen.getByText('In the draw')).toBeInTheDocument();
+      expect(screen.getByText('Alice')).toBeInTheDocument();
+      expect(screen.getByText('Bob')).toBeInTheDocument();
+      expect(screen.getByText('Charlie')).toBeInTheDocument();
+    });
+
+    it('surfaces the entrant count against the seat count', async () => {
+      render(AttendeeList, { props: { attendees: overSubscribed, maxAttendees: 2, lotteryPredraw: true } });
+      await fireEvent.click(screen.getByRole('button', { name: /Show Responses/ }));
+      expect(screen.getByText(/3 for 2 seats/)).toBeInTheDocument();
+    });
   });
 
   it('shows delete buttons when showDeleteButton is true', async () => {

--- a/client/src/__tests__/routes/EventDetailPage.test.ts
+++ b/client/src/__tests__/routes/EventDetailPage.test.ts
@@ -211,6 +211,48 @@ describe('EventDetailPage — admin view', () => {
       expect(screen.getByRole('link', { name: 'Edit event' })).toBeInTheDocument();
     });
   });
+
+  it('sends admin credentials on a sign-up so the server can stamp lottery priority', async () => {
+    // Regression guard: a logged-in admin's sign-up must carry credentials, or the
+    // server treats it as anonymous (priority_weight 0) and the admin gets no
+    // priority and no badge. The client only did this during early access before.
+    localStorage.setItem('credentials', 'admin:secret');
+    const fetchMock = vi.fn().mockImplementation((url: RequestInfo, opts?: RequestInit) => {
+      const u = String(url);
+      if (u.endsWith('/events/evt-1/rsvp') && opts?.method === 'POST') {
+        return Promise.resolve({
+          ok: true,
+          status: 201,
+          json: async () => ({ rsvp: { id: 'new-id', name: 'Boss', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok-new' } }),
+        } as Response);
+      }
+      // Admin-login check and the post-submit event refetch.
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        json: async () => ({ rsvp: [], event: { ...baseEvent, selection_mode: 'lottery' }, poll: null, serverTime: Date.now() }),
+      } as Response);
+    });
+    vi.stubGlobal('fetch', fetchMock);
+
+    const lotteryEvent: Event = { ...baseEvent, selection_mode: 'lottery' };
+    render(EventDetailPage, { props: { data: buildData(lotteryEvent) } });
+
+    // Wait for the admin check to resolve (the draw button only renders for admins).
+    await screen.findByRole('button', { name: 'Run the draw' });
+
+    await fireEvent.input(screen.getByPlaceholderText('Enter your name'), { target: { value: 'Boss' } });
+    await fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    await waitFor(() => {
+      const post = fetchMock.mock.calls.find(
+        ([url, opts]) => String(url).endsWith('/events/evt-1/rsvp') && (opts as RequestInit)?.method === 'POST',
+      );
+      expect(post).toBeTruthy();
+      const headers = (post![1] as RequestInit).headers as Headers;
+      expect(headers.get('Authorization')).toBe('Basic admin:secret');
+    });
+  });
 });
 
 describe('EventDetailPage — null event (not found)', () => {
@@ -540,5 +582,33 @@ describe('EventDetailPage — registration opens in future', () => {
     expect(screen.getByText('1:00:00')).toBeInTheDocument();
 
     restoreIntl();
+  });
+
+  it('does not gate a lottery sign-up behind registration_opens_at (the draw is the gate)', async () => {
+    // Regression guard: in lottery mode the server ignores registration_opens_at,
+    // so the client must too — a non-admin visiting before the entry-window time
+    // must still be able to sign up, not see a "Registration opens in" countdown
+    // with a disabled form.
+    const futureDate = new Date(Date.now() + 3_600_000).toISOString();
+    const event: Event = {
+      ...baseEvent,
+      selection_mode: 'lottery',
+      registration_opens_at: futureDate,
+    };
+
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({
+        ok: false,
+        status: 401,
+        json: async () => ({}),
+      } as Response),
+    );
+
+    render(EventDetailPage, { props: { data: buildData(event) } });
+
+    const submit = await screen.findByRole('button', { name: 'Submit' });
+    expect(submit).not.toBeDisabled();
+    expect(screen.queryByText(/Registration opens in/)).not.toBeInTheDocument();
   });
 });

--- a/client/src/lib/AttendeeList.svelte
+++ b/client/src/lib/AttendeeList.svelte
@@ -6,6 +6,15 @@
   export let onDelete: (id: string) => void = () => {};
   export let showDeleteButton: boolean = true;
   export let maxAttendees: number = 0;
+  // Before a lottery draw, sign-up order is meaningless, so there is no
+  // "Going vs Waitlist" split — everyone going is an equal entrant in the draw.
+  export let lotteryPredraw: boolean = false;
+  // Priority weight only affects lottery draws, so the "Priority" badge is only
+  // meaningful for lottery events. Admins are stamped a weight on every sign-up
+  // (lottery or FIFO), so without this gate a FIFO admin entry would show it too.
+  export let isLottery: boolean = false;
+
+  $: goingAttendees = attendees.filter((a) => a.status === "going");
 
   const groups = [
     {
@@ -90,21 +99,31 @@
       >
         {#each groups as group (group.key)}
           {#if group.key === "going"}
-            {#if attendees.filter((a) => a.status === "going").length}
-              <li class="bg-gray-100 px-4 py-2 font-semibold dark:bg-gray-800 {group.color}">
+            {#if goingAttendees.length}
+              <li class="bg-gray-100 px-4 py-2 font-semibold dark:bg-gray-800 {lotteryPredraw ? 'text-purple-700 dark:text-purple-300' : group.color}">
                 <div class="flex flex-col items-start">
                   <span class="flex items-center">
-                    <span>{group.label}</span>
-                    <span class="ml-1 flex min-w-8 items-center justify-center text-xs text-gray-500">
-                      ({Math.min(attendees.filter((a) => a.status === "going").length, maxAttendees)})
-                    </span>
+                    {#if lotteryPredraw}
+                      <span>In the draw</span>
+                      <span class="ml-1 flex min-w-8 items-center justify-center text-xs text-gray-500">
+                        ({goingAttendees.length}{maxAttendees ? ` for ${maxAttendees} seat${maxAttendees > 1 ? "s" : ""}` : ""})
+                      </span>
+                    {:else}
+                      <span>{group.label}</span>
+                      <span class="ml-1 flex min-w-8 items-center justify-center text-xs text-gray-500">
+                        ({Math.min(goingAttendees.length, maxAttendees)})
+                      </span>
+                    {/if}
                   </span>
                 </div>
               </li>
-              {#each attendees.filter((a) => a.status === "going").slice(0, maxAttendees) as a (a.id)}
+              {#each (lotteryPredraw ? goingAttendees : goingAttendees.slice(0, maxAttendees)) as a (a.id)}
                 <li class="flex flex-row items-start gap-4 px-4 py-2">
                   <div class="flex min-w-0 flex-row items-center gap-4">
                     <span class="min-w-0 break-words font-medium">{a.name}</span>
+                    {#if isLottery && a.priority_weight && a.priority_weight > 0}
+                      <span class="shrink-0 rounded bg-purple-100 px-1.5 py-0.5 text-xs font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" title="Priority spot in the lottery">Priority</span>
+                    {/if}
                     {#if a.guests > 0}
                       <span class="text-xs text-gray-400">(+{a.guests} guest{a.guests > 1 ? "s" : ""})</span>
                     {/if}
@@ -125,21 +144,24 @@
                 </li>
               {/each}
             {/if}
-            {#if attendees.filter((a) => a.status === "going").length > maxAttendees}
+            {#if !lotteryPredraw && goingAttendees.length > maxAttendees}
               <li class="bg-gray-100 px-4 py-2 font-semibold dark:bg-gray-800 text-orange-600 dark:text-orange-400">
                 <div class="flex flex-col items-start">
                   <span class="flex items-center">
                     <span>Waitlist</span>
                     <span class="ml-1 flex min-w-8 items-center justify-center text-xs text-gray-500">
-                      ({attendees.filter((a) => a.status === "going").length - maxAttendees})
+                      ({goingAttendees.length - maxAttendees})
                     </span>
                   </span>
                 </div>
               </li>
-              {#each attendees.filter((a) => a.status === "going").slice(maxAttendees) as a (a.id)}
+              {#each goingAttendees.slice(maxAttendees) as a (a.id)}
                 <li class="flex flex-row items-start gap-4 px-4 py-2">
                   <div class="flex min-w-0 flex-row items-center gap-4">
                     <span class="min-w-0 break-words font-medium">{a.name}</span>
+                    {#if isLottery && a.priority_weight && a.priority_weight > 0}
+                      <span class="shrink-0 rounded bg-purple-100 px-1.5 py-0.5 text-xs font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" title="Priority spot in the lottery">Priority</span>
+                    {/if}
                     {#if a.guests > 0}
                       <span class="text-xs text-gray-400">(+{a.guests} guest{a.guests > 1 ? "s" : ""})</span>
                     {/if}
@@ -176,6 +198,9 @@
                 <li class="flex flex-row items-start gap-4 px-4 py-2">
                   <div class="flex min-w-0 flex-row items-center gap-4">
                     <span class="min-w-0 break-words font-medium">{a.name}</span>
+                    {#if isLottery && a.priority_weight && a.priority_weight > 0}
+                      <span class="shrink-0 rounded bg-purple-100 px-1.5 py-0.5 text-xs font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" title="Priority spot in the lottery">Priority</span>
+                    {/if}
                     {#if a.guests > 0}
                       <span class="text-xs text-gray-400">(+{a.guests} guest{a.guests > 1 ? "s" : ""})</span>
                     {/if}
@@ -212,6 +237,9 @@
                 <li class="flex flex-row items-start gap-4 px-4 py-2">
                   <div class="flex min-w-0 flex-row items-center gap-4">
                     <span class="min-w-0 break-words font-medium">{a.name}</span>
+                    {#if isLottery && a.priority_weight && a.priority_weight > 0}
+                      <span class="shrink-0 rounded bg-purple-100 px-1.5 py-0.5 text-xs font-semibold text-purple-700 dark:bg-purple-900/40 dark:text-purple-300" title="Priority spot in the lottery">Priority</span>
+                    {/if}
                     {#if a.guests > 0}
                       <span class="text-xs text-gray-400">(+{a.guests} guest{a.guests > 1 ? "s" : ""})</span>
                     {/if}

--- a/client/src/routes/create-event/+page.svelte
+++ b/client/src/routes/create-event/+page.svelte
@@ -10,6 +10,7 @@
   let startTime = "";
   let endTime = "";
   let registrationOpensAtLocal = "";
+  let selectionMode: "fifo" | "lottery" = "fifo";
   let loading = false;
   let createdEventId: string | null = null;
   let authError = false;
@@ -45,7 +46,7 @@
     }
     loading = true;
     try {
-      const body: Record<string, unknown> = { name, date, startTime, endTime, maxAttendees, location };
+      const body: Record<string, unknown> = { name, date, startTime, endTime, maxAttendees, location, selectionMode };
       if (registrationOpensAtLocal) {
         body.registrationOpensAt = new Date(registrationOpensAtLocal).toISOString();
       }
@@ -66,6 +67,7 @@
         maxAttendees = "";
         location = "";
         registrationOpensAtLocal = "";
+        selectionMode = "fifo";
         // Optionally, you could also focus the first input
       } else {
         alert(data.error || "Failed to create event.");
@@ -173,6 +175,25 @@
         />
       </div>
       <div>
+        <label for="selectionMode" class="mb-1 block font-semibold">Seat Allocation</label>
+        <select
+          id="selectionMode"
+          name="selectionMode"
+          bind:value={selectionMode}
+          class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
+        >
+          <option value="fifo">First come, first served</option>
+          <option value="lottery">Lottery (random draw)</option>
+        </select>
+        <p class="mt-1 text-xs text-gray-500">
+          {#if selectionMode === "lottery"}
+            Sign-ups stay open with no rush; you run a random draw from the admin controls when the entry window closes. Admins get a priority spot.
+          {:else}
+            Seats fill in the order people sign up.
+          {/if}
+        </p>
+      </div>
+      <div>
         <label for="registrationOpensAt" class="mb-1 block font-semibold">Registration Opens At</label>
         <input
           id="registrationOpensAt"
@@ -181,7 +202,13 @@
           bind:value={registrationOpensAtLocal}
           class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
         />
-        <p class="mt-1 text-xs text-gray-500">Leave empty to open registration immediately. Admins can always register early.</p>
+        <p class="mt-1 text-xs text-gray-500">
+          {#if selectionMode === "lottery"}
+            Optional. When the entry window opens. In lottery mode this does not gate sign-ups — the draw decides who gets in.
+          {:else}
+            Leave empty to open registration immediately. Admins can always register early.
+          {/if}
+        </p>
       </div>
       <div>
         <label for="maxAttendees" class="mb-1 block font-semibold"

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -41,6 +41,11 @@
   let attendees = data.rsvp;
   $: goingCount = getTotalAttendance(attendees);
 
+  const isLottery = event?.selection_mode === "lottery";
+  let drawnAt: string | null = event?.drawn_at ?? null;
+  let drawing = false;
+  let drawError = "";
+
   let rsvp: RsvpStatus = "going";
   let attendeeName = "";
   let guests = "0";
@@ -53,14 +58,19 @@
   let users: User[] | undefined;
   let isAdmin = false;
   let mounted = false;
-  let registrationOpen = !event.registration_opens_at;
-  let publicRegistrationOpen = !event.registration_opens_at;
-  let countdownReady = !event.registration_opens_at;
+  // Lottery sign-ups are never gated by registration_opens_at — the draw is the
+  // gate, so the form stays open (matches the server, which skips the gate for
+  // lottery). registration_opens_at, if set, is only an informational entry-window
+  // hint in lottery mode.
+  let registrationOpen = isLottery || !event.registration_opens_at;
+  let publicRegistrationOpen = isLottery || !event.registration_opens_at;
+  // Lottery mode never shows a countdown, so it starts ready for the same reason.
+  let countdownReady = isLottery || !event.registration_opens_at;
   let countdown = '';
   let countdownInterval: ReturnType<typeof setInterval> | null = null;
 
   function startCountdown() {
-    if (!event.registration_opens_at) {
+    if (isLottery || !event.registration_opens_at) {
       registrationOpen = true;
       publicRegistrationOpen = true;
       countdownReady = true;
@@ -168,7 +178,6 @@
         token: user?.token
       };
 
-      const isAdminEarlyAccess = isAdmin && !!event.registration_opens_at && new Date() < new Date(event.registration_opens_at);
       if (user?.id) {
         const res = await fetch(`${API_HOST}/events/${event.id}/rsvp/${user.id}`, {
           method: "PATCH",
@@ -177,7 +186,10 @@
         });
         if (!res.ok) return;
       } else {
-        const rsvpFetch = isAdminEarlyAccess ? adminFetch : fetch;
+        // Send the RSVP with admin credentials when logged in, so the server can
+        // identify it as an admin sign-up — that's what stamps the lottery
+        // priority weight and (for FIFO) grants early-registration access.
+        const rsvpFetch = isAdmin ? adminFetch : fetch;
         const response = await rsvpFetch(`${API_HOST}/events/${event.id}/rsvp`, {
           method: "POST",
           headers: { "Content-Type": "application/json" },
@@ -206,6 +218,33 @@
       setTimeout(() => (showToast = false), 2000);
     } catch (err) {
       console.error(err)
+    }
+  }
+
+  async function runDraw() {
+    if (!window.confirm('Run the lottery draw now? This randomly orders everyone who is going and cannot be undone.')) {
+      return;
+    }
+    drawError = '';
+    drawing = true;
+    try {
+      const res = await adminFetch(`${API_HOST}/admin/events/${event.id}/draw`, { method: 'POST' });
+      if (res.ok) {
+        const body = await res.json();
+        drawnAt = body.drawnAt ?? new Date().toISOString();
+        const refetchRes = await fetch(`${API_HOST}/events/${event.id}`);
+        if (refetchRes.ok) {
+          const refetchData = await refetchRes.json();
+          attendees = refetchData.rsvp;
+        }
+      } else {
+        const body = await res.json().catch(() => ({}));
+        drawError = body.error || 'Failed to run the draw.';
+      }
+    } catch {
+      drawError = 'Error running the draw.';
+    } finally {
+      drawing = false;
     }
   }
 
@@ -302,7 +341,37 @@
       </div>
     {/if}
 
-    <AttendeeList {attendees} maxAttendees={event.max_attendees} onDelete={onDeleteAttendee} showDeleteButton={isAdmin} />
+    {#if isLottery}
+      <div class="mb-4 rounded-lg border border-purple-200 bg-purple-50 px-4 py-3 dark:border-purple-700 dark:bg-purple-900/20">
+        {#if drawnAt}
+          <p class="text-sm font-semibold text-purple-800 dark:text-purple-200">
+            🎲 Seats were allocated by random draw on {new Date(drawnAt).toLocaleString()}.
+          </p>
+          <p class="mt-1 text-xs text-purple-700 dark:text-purple-300">
+            The list below is in the drawn order. Anyone who signs up now joins the end of the waitlist.
+          </p>
+        {:else}
+          <p class="text-sm font-semibold text-purple-800 dark:text-purple-200">
+            🎲 This is a lottery event — seats are allocated by a random draw, not by sign-up order.
+          </p>
+          {#if isAdmin}
+            <button
+              type="button"
+              class="mt-3 flex items-center justify-center rounded bg-purple-600 px-4 py-2 text-sm font-bold text-white shadow transition-colors hover:bg-purple-700 disabled:opacity-60"
+              on:click={runDraw}
+              disabled={drawing}
+            >
+              {drawing ? 'Drawing…' : 'Run the draw'}
+            </button>
+          {/if}
+        {/if}
+        {#if drawError}
+          <p class="mt-2 text-xs font-semibold text-red-600 dark:text-red-400">{drawError}</p>
+        {/if}
+      </div>
+    {/if}
+
+    <AttendeeList {attendees} maxAttendees={event.max_attendees} onDelete={onDeleteAttendee} showDeleteButton={isAdmin} {isLottery} lotteryPredraw={isLottery && !drawnAt} />
 
     {#if countdownReady && !registrationOpen}
       <div class="mb-4 rounded-lg bg-yellow-50 dark:bg-yellow-900/20 border border-yellow-200 dark:border-yellow-700 px-4 py-4 text-center">
@@ -364,7 +433,7 @@
         disabled={!registrationOpen}
       />
     {:else if status !== undefined}
-      {#if rsvp === 'going' && isUserOnWaitlist(attendees, user?.id ?? '', event.max_attendees)}
+      {#if rsvp === 'going' && !(isLottery && !drawnAt) && isUserOnWaitlist(attendees, user?.id ?? '', event.max_attendees)}
         <div class="mb-4 flex w-full items-center justify-center">
           <div class="relative w-full rounded px-4 py-2 font-semibold flex items-center bg-blue-100 dark:bg-blue-300 text-blue-900 dark:text-blue-800">
             <span>

--- a/client/src/routes/events/[id]/edit/+page.svelte
+++ b/client/src/routes/events/[id]/edit/+page.svelte
@@ -14,6 +14,7 @@
   let startTime = "";
   let endTime = "";
   let registrationOpensAt = "";
+  let selectionMode: "fifo" | "lottery" = "fifo";
   let loading = false;
   let fetchLoading = true;
   let authError = false;
@@ -45,6 +46,7 @@
       endTime = event.end_time ?? "";
       maxAttendees = event.max_attendees ?? "";
       location = event.location;
+      selectionMode = event.selection_mode === "lottery" ? "lottery" : "fifo";
       if (event.registration_opens_at) {
         const d = new Date(event.registration_opens_at);
         const pad = (n: number) => String(n).padStart(2, '0');
@@ -72,7 +74,7 @@
       const response = await adminFetch(`${API_HOST}/admin/events/${eventId}`, {
         method: "PATCH",
         headers: { "Content-Type": "application/json" },
-        body: JSON.stringify({ name, date, startTime, endTime, maxAttendees: maxAttendees === "" ? null : maxAttendees, location, registrationOpensAt: registrationOpensAt ? new Date(registrationOpensAt).toISOString() : null }),
+        body: JSON.stringify({ name, date, startTime, endTime, maxAttendees: maxAttendees === "" ? null : maxAttendees, location, registrationOpensAt: registrationOpensAt ? new Date(registrationOpensAt).toISOString() : null, selectionMode }),
       });
       const data = await response.json();
       if (response.ok) {
@@ -197,6 +199,25 @@
           aria-required="true"
           class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
         />
+      </div>
+      <div>
+        <label for="selectionMode" class="mb-1 block font-semibold">Seat Allocation</label>
+        <select
+          id="selectionMode"
+          name="selectionMode"
+          bind:value={selectionMode}
+          class="w-full rounded border border-gray-300 px-4 py-2 focus:ring-2 focus:ring-primary focus:outline-none dark:border-gray-700 dark:bg-background-dark dark:text-text-dark"
+        >
+          <option value="fifo">First come, first served</option>
+          <option value="lottery">Lottery (random draw)</option>
+        </select>
+        <p class="mt-1 text-xs text-gray-500">
+          {#if selectionMode === "lottery"}
+            Sign-ups stay open with no rush; run the draw from the event page when the entry window closes.
+          {:else}
+            Seats fill in the order people sign up.
+          {/if}
+        </p>
       </div>
       <div>
         <label for="registrationOpensAt" class="mb-1 block font-semibold">Registration Opens At</label>

--- a/client/src/types/Event.ts
+++ b/client/src/types/Event.ts
@@ -8,4 +8,6 @@ export type Event = {
   location: string;
   created_at?: string;
   registration_opens_at?: string;
+  selection_mode?: "fifo" | "lottery";
+  drawn_at?: string | null;
 };

--- a/client/src/types/Rsvp.ts
+++ b/client/src/types/Rsvp.ts
@@ -9,4 +9,6 @@ export type Rsvp = {
   created_at?: string;
   updated_at?: string;
   token: string;
+  priority_weight?: number;
+  lottery_rank?: number | null;
 };

--- a/server/src/__tests__/integration/lottery.test.ts
+++ b/server/src/__tests__/integration/lottery.test.ts
@@ -1,0 +1,210 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import server from './testServer';
+import db from '../../db';
+
+const AUTH = 'Basic testadmin:testpass';
+
+const BASE_EVENT = {
+  name: 'Lottery Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Venue',
+};
+
+async function createEvent(overrides: Record<string, unknown> = {}) {
+  const res = await request(server)
+    .post('/admin/create-event')
+    .set('Authorization', AUTH)
+    .send({ ...BASE_EVENT, ...overrides });
+  return res.body.event;
+}
+
+beforeEach(() => {
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+});
+
+describe('event selection_mode', () => {
+  it('defaults to fifo when not specified', async () => {
+    const event = await createEvent();
+    expect(event.selection_mode).toBe('fifo');
+  });
+
+  it('creates an event in lottery mode', async () => {
+    const event = await createEvent({ selectionMode: 'lottery' });
+    expect(event.selection_mode).toBe('lottery');
+    expect(event.drawn_at).toBeFalsy();
+  });
+
+  it('rejects an invalid selectionMode', async () => {
+    await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, selectionMode: 'bogus' })
+      .expect(400);
+  });
+
+  it('can switch an existing event to lottery mode via PATCH', async () => {
+    const event = await createEvent();
+    await request(server)
+      .patch(`/admin/events/${event.id}`)
+      .set('Authorization', AUTH)
+      .send({ selectionMode: 'lottery' })
+      .expect(200);
+    const fetched = await request(server).get(`/events/${event.id}`);
+    expect(fetched.body.event.selection_mode).toBe('lottery');
+  });
+});
+
+describe('lottery registration window', () => {
+  it('does NOT block sign-ups before registrationOpensAt (the draw is the gate)', async () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const event = await createEvent({ selectionMode: 'lottery', registrationOpensAt: future });
+
+    // In FIFO mode this same request would be 403; in lottery mode it must succeed.
+    await request(server)
+      .post(`/events/${event.id}/rsvp`)
+      .send({ name: 'Alice', status: 'going' })
+      .expect(201);
+  });
+
+  it('stamps a priority weight on an admin-created RSVP and zero for the public', async () => {
+    const event = await createEvent({ selectionMode: 'lottery' });
+
+    await request(server)
+      .post(`/events/${event.id}/rsvp`)
+      .set('Authorization', AUTH)
+      .send({ name: 'Admin', status: 'going' })
+      .expect(201);
+    await request(server)
+      .post(`/events/${event.id}/rsvp`)
+      .send({ name: 'Public', status: 'going' })
+      .expect(201);
+
+    const fetched = await request(server).get(`/events/${event.id}`);
+    const byName = Object.fromEntries(fetched.body.rsvp.map((r: any) => [r.name, r.priority_weight]));
+    expect(byName.Admin).toBeGreaterThan(0);
+    expect(byName.Public).toBe(0);
+  });
+});
+
+describe('POST /admin/events/:id/draw', () => {
+  it('requires admin authentication', async () => {
+    const event = await createEvent({ selectionMode: 'lottery' });
+    await request(server).post(`/admin/events/${event.id}/draw`).expect(401);
+  });
+
+  it('returns 404 for a non-existent event', async () => {
+    await request(server)
+      .post('/admin/events/ghost/draw')
+      .set('Authorization', AUTH)
+      .expect(404);
+  });
+
+  it('rejects a draw on a fifo event', async () => {
+    const event = await createEvent();
+    await request(server)
+      .post(`/admin/events/${event.id}/draw`)
+      .set('Authorization', AUTH)
+      .expect(400);
+  });
+
+  it('draws the lottery and assigns ranks reflected in GET /events/:id', async () => {
+    const event = await createEvent({ selectionMode: 'lottery' });
+    for (const name of ['Alice', 'Bob', 'Carol']) {
+      await request(server).post(`/events/${event.id}/rsvp`).send({ name, status: 'going' });
+    }
+
+    const drawRes = await request(server)
+      .post(`/admin/events/${event.id}/draw`)
+      .set('Authorization', AUTH)
+      .expect(200);
+    expect(drawRes.body.drawnAt).toBeTruthy();
+
+    const fetched = await request(server).get(`/events/${event.id}`);
+    expect(fetched.body.event.drawn_at).toBeTruthy();
+    const ranks = fetched.body.rsvp.map((r: any) => r.lottery_rank).sort();
+    expect(ranks).toEqual([1, 2, 3]);
+  });
+
+  it('places a maybe→going change made after the draw at the end of the list', async () => {
+    const event = await createEvent({ selectionMode: 'lottery' });
+    await request(server).post(`/events/${event.id}/rsvp`).send({ name: 'Alice', status: 'going' });
+    const bobRes = await request(server).post(`/events/${event.id}/rsvp`).send({ name: 'Bob', status: 'maybe' });
+    const { id: bobId, token } = bobRes.body.rsvp;
+
+    await request(server)
+      .post(`/admin/events/${event.id}/draw`)
+      .set('Authorization', AUTH)
+      .expect(200);
+
+    // Bob flips maybe -> going after the draw; he must land at the back, unranked.
+    await request(server)
+      .patch(`/events/${event.id}/rsvp/${bobId}`)
+      .send({ token, name: 'Bob', status: 'going', guests: 0 })
+      .expect(200);
+
+    const fetched = await request(server).get(`/events/${event.id}`);
+    const rows = fetched.body.rsvp;
+    const bob = rows.find((r: any) => r.id === bobId);
+    expect(bob.status).toBe('going');
+    expect(bob.lottery_rank).toBeNull();
+    expect(rows[rows.length - 1].id).toBe(bobId);
+  });
+
+  it('does not let a returning entrant snatch back a seat already promoted to a waitlister', async () => {
+    const event = await createEvent({ selectionMode: 'lottery', maxAttendees: 2 });
+    const rsvps: Record<string, { id: string; token: string }> = {};
+    for (const name of ['A', 'B', 'C']) {
+      const res = await request(server).post(`/events/${event.id}/rsvp`).send({ name, status: 'going' });
+      rsvps[name] = { id: res.body.rsvp.id, token: res.body.rsvp.token };
+    }
+
+    await request(server)
+      .post(`/admin/events/${event.id}/draw`)
+      .set('Authorization', AUTH)
+      .expect(200);
+
+    // Identify the last in-capacity seat holder (rank 2) and the first waitlister (rank 3).
+    let fetched = await request(server).get(`/events/${event.id}`);
+    const drawn = fetched.body.rsvp;
+    const seatHolder = drawn.find((r: any) => r.lottery_rank === 2);
+    const waitlister = drawn.find((r: any) => r.lottery_rank === 3);
+    const seatHolderToken = Object.values(rsvps).find((r) => r.id === seatHolder.id)!.token;
+
+    // Seat holder leaves, then returns to going.
+    await request(server)
+      .patch(`/events/${event.id}/rsvp/${seatHolder.id}`)
+      .send({ token: seatHolderToken, name: seatHolder.name, status: 'not_going', guests: 0 })
+      .expect(200);
+    await request(server)
+      .patch(`/events/${event.id}/rsvp/${seatHolder.id}`)
+      .send({ token: seatHolderToken, name: seatHolder.name, status: 'going', guests: 0 })
+      .expect(200);
+
+    fetched = await request(server).get(`/events/${event.id}`);
+    const rows = fetched.body.rsvp;
+    const seatHolderAfter = rows.find((r: any) => r.id === seatHolder.id);
+    const waitlisterAfter = rows.find((r: any) => r.id === waitlister.id);
+    // The waitlister keeps rank 2 and stays in; the returner is now last.
+    expect(waitlisterAfter.lottery_rank).toBe(3);
+    expect(seatHolderAfter.lottery_rank).toBeNull();
+    expect(rows[rows.length - 1].id).toBe(seatHolder.id);
+  });
+
+  it('is guarded against re-running once drawn', async () => {
+    const event = await createEvent({ selectionMode: 'lottery' });
+    await request(server).post(`/events/${event.id}/rsvp`).send({ name: 'Alice', status: 'going' });
+
+    await request(server)
+      .post(`/admin/events/${event.id}/draw`)
+      .set('Authorization', AUTH)
+      .expect(200);
+    await request(server)
+      .post(`/admin/events/${event.id}/draw`)
+      .set('Authorization', AUTH)
+      .expect(409);
+  });
+});

--- a/server/src/__tests__/unit/services/rsvpService.test.ts
+++ b/server/src/__tests__/unit/services/rsvpService.test.ts
@@ -5,6 +5,7 @@ import {
   getMyRsvpsService,
   getRsvpByEventId,
   rsvpToEventService,
+  runDrawForEvent,
   updateRsvpByToken,
 } from '../../../services/rsvp';
 import { createEvent, deleteEvent } from '../../../services/event';
@@ -204,6 +205,138 @@ describe('getMyRsvpsService', () => {
   it('ignores pairs that do not exist', async () => {
     const results = await getMyRsvpsService([{ rsvpId: 'ghost', eventId: 'ghost' }]);
     expect(results).toHaveLength(0);
+  });
+});
+
+describe('runDrawForEvent', () => {
+  function createLotteryEvent() {
+    return createEvent({ ...BASE_EVENT, selectionMode: 'lottery' }).id;
+  }
+
+  it('assigns a lottery_rank to every going RSVP and records drawn_at on the event', () => {
+    const lotteryId = createLotteryEvent();
+    rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: 'Alice', status: 'going' });
+    rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: 'Bob', status: 'going' });
+    rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: 'Carol', status: 'going' });
+
+    runDrawForEvent(lotteryId);
+
+    const ranks = (getRsvpByEventId(lotteryId) as any[]).map((r) => r.lottery_rank).sort();
+    expect(ranks).toEqual([1, 2, 3]);
+    const event = db.prepare('SELECT drawn_at FROM events WHERE id = ?').get(lotteryId) as any;
+    expect(event.drawn_at).toBeTruthy();
+  });
+
+  it('does not rank non-going RSVPs', () => {
+    const lotteryId = createLotteryEvent();
+    rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: 'Alice', status: 'going' });
+    rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: 'Maybe', status: 'maybe' });
+
+    runDrawForEvent(lotteryId);
+
+    const rows = getRsvpByEventId(lotteryId) as any[];
+    const maybeRow = rows.find((r) => r.name === 'Maybe');
+    expect(maybeRow.lottery_rank).toBeNull();
+  });
+
+  it('seeds higher priority_weight to the front of the draw', () => {
+    const lotteryId = createLotteryEvent();
+    // Many zero-weight entrants plus one priority entrant; a priority weight must
+    // always win rank 1 regardless of the random tiebreak among the rest.
+    for (let i = 0; i < 20; i++) {
+      rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: `Reg${i}`, status: 'going' });
+    }
+    const vipId = uuidv4();
+    rsvpToEventService({ id: vipId, eventId: lotteryId, name: 'Vip', status: 'going', priorityWeight: 1 });
+
+    runDrawForEvent(lotteryId);
+
+    const vip = db.prepare('SELECT lottery_rank FROM rsvp WHERE id = ?').get(vipId) as any;
+    expect(vip.lottery_rank).toBe(1);
+  });
+
+  it('keeps a post-draw maybe→going entrant at the back of the list (null rank)', () => {
+    const lotteryId = createLotteryEvent();
+    const goingId = uuidv4();
+    rsvpToEventService({ id: goingId, eventId: lotteryId, name: 'Alice', status: 'going' });
+    const maybeId = uuidv4();
+    const maybeRsvp = rsvpToEventService({ id: maybeId, eventId: lotteryId, name: 'Bob', status: 'maybe' }) as any;
+
+    runDrawForEvent(lotteryId);
+
+    // Bob was 'maybe' at draw time, so he was never ranked. Flipping to 'going'
+    // afterwards must not jump him ahead of the drawn entrants — he joins the back.
+    updateRsvpByToken({ eventId: lotteryId, rsvpId: maybeId, token: maybeRsvp.token, name: 'Bob', status: 'going', guests: 0 });
+
+    const ordered = getRsvpByEventId(lotteryId) as any[];
+    const bob = ordered.find((r) => r.id === maybeId);
+    expect(bob.status).toBe('going');
+    expect(bob.lottery_rank).toBeNull();
+    expect(ordered[ordered.length - 1].id).toBe(maybeId);
+    expect(ordered[0].id).toBe(goingId);
+  });
+
+  it('forfeits the drawn rank when a going entrant leaves and rejoins (no seat take-backs)', () => {
+    const lotteryId = createLotteryEvent();
+    // Three seats, four entrants: ranks 1-3 are in, rank 4 is waitlisted.
+    db.prepare('UPDATE events SET max_attendees = 3 WHERE id = ?').run(lotteryId);
+    const winners: any[] = [];
+    for (const name of ['A', 'B', 'C', 'D']) {
+      winners.push(rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name, status: 'going' }) as any);
+    }
+    runDrawForEvent(lotteryId);
+
+    const ranked = getRsvpByEventId(lotteryId) as any[];
+    const seatHolder = ranked[2]; // rank 3, the last person inside capacity
+    const waitlisted = ranked[3]; // rank 4, first on the waitlist
+    const seatHolderRow = winners.find((w) => w.id === seatHolder.id);
+
+    // Seat holder steps out...
+    updateRsvpByToken({ eventId: lotteryId, rsvpId: seatHolder.id, token: seatHolderRow.token, name: seatHolder.name, status: 'not_going', guests: 0 });
+    // ...then changes their mind and comes back to going.
+    updateRsvpByToken({ eventId: lotteryId, rsvpId: seatHolder.id, token: seatHolderRow.token, name: seatHolder.name, status: 'going', guests: 0 });
+
+    const after = getRsvpByEventId(lotteryId) as any[];
+    const seatHolderAfter = after.find((r) => r.id === seatHolder.id);
+    const waitlistedAfter = after.find((r) => r.id === waitlisted.id);
+    // The returning entrant lost their rank and is now behind the promoted waitlister.
+    expect(seatHolderAfter.lottery_rank).toBeNull();
+    expect(waitlistedAfter.lottery_rank).toBe(4);
+    expect(after[after.length - 1].id).toBe(seatHolder.id);
+  });
+
+  it('preserves the drawn rank when a going entrant edits without leaving going', () => {
+    const lotteryId = createLotteryEvent();
+    const id = uuidv4();
+    const row = rsvpToEventService({ id, eventId: lotteryId, name: 'Alice', status: 'going' }) as any;
+    runDrawForEvent(lotteryId);
+    const rankBefore = (db.prepare('SELECT lottery_rank FROM rsvp WHERE id = ?').get(id) as any).lottery_rank;
+
+    // Editing guest count while staying 'going' must not demote her.
+    updateRsvpByToken({ eventId: lotteryId, rsvpId: id, token: row.token, name: 'Alice', status: 'going', guests: 2 });
+
+    const rankAfter = (db.prepare('SELECT lottery_rank FROM rsvp WHERE id = ?').get(id) as any).lottery_rank;
+    expect(rankAfter).toBe(rankBefore);
+    expect(rankAfter).not.toBeNull();
+  });
+
+  it('orders a drawn lottery by lottery_rank, with post-draw signups last', () => {
+    const lotteryId = createLotteryEvent();
+    const firstId = uuidv4();
+    const secondId = uuidv4();
+    rsvpToEventService({ id: firstId, eventId: lotteryId, name: 'First', status: 'going' });
+    rsvpToEventService({ id: secondId, eventId: lotteryId, name: 'Second', status: 'going' });
+
+    runDrawForEvent(lotteryId);
+
+    // Someone signs up after the draw — they have no rank and must fall to the back.
+    rsvpToEventService({ id: uuidv4(), eventId: lotteryId, name: 'Latecomer', status: 'going' });
+
+    const ordered = getRsvpByEventId(lotteryId) as any[];
+    expect(ordered[ordered.length - 1].name).toBe('Latecomer');
+    // The first two are the ranked entries, in ascending rank order.
+    expect(ordered[0].lottery_rank).toBe(1);
+    expect(ordered[1].lottery_rank).toBe(2);
   });
 });
 

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -5,15 +5,18 @@ import { getPollByEventId } from '../services/poll';
 import { generateIcs } from '../utils/generateIcs';
 
 export const createEvent = async (req: Request, res: Response, next: Function) => {
-  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = req.body;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt, selectionMode } = req.body;
   if (!name || !date || !location || !startTime || !endTime) {
     return res.status(400).json({ error: "Name, date, startTime, endTime, and location are required." });
   }
   if (endTime <= startTime) {
     return res.status(400).json({ error: "endTime must be after startTime." });
   }
+  if (selectionMode !== undefined && selectionMode !== 'fifo' && selectionMode !== 'lottery') {
+    return res.status(400).json({ error: "selectionMode must be 'fifo' or 'lottery'." });
+  }
   try {
-    const event = await createEventService({ name, date, startTime, endTime, maxAttendees, location, registrationOpensAt });
+    const event = await createEventService({ name, date, startTime, endTime, maxAttendees, location, registrationOpensAt, selectionMode });
     res.status(201).json({
       message: "Event created successfully!",
       event
@@ -94,12 +97,15 @@ export const getAllEvents = async (req: Request, res: Response, next: Function) 
 
 export const updateEvent = async (req: Request, res: Response, next: Function) => {
   const { id } = req.params;
-  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = req.body;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt, selectionMode } = req.body;
   if (endTime && startTime && endTime <= startTime) {
     return res.status(400).json({ error: "endTime must be after startTime." });
   }
+  if (selectionMode !== undefined && selectionMode !== 'fifo' && selectionMode !== 'lottery') {
+    return res.status(400).json({ error: "selectionMode must be 'fifo' or 'lottery'." });
+  }
   try {
-    const event = await updateEventService(id, { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt });
+    const event = await updateEventService(id, { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt, selectionMode });
     if (!event) {
       return res.status(404).json({ error: "Event not found" });
     }

--- a/server/src/controllers/rsvpController.ts
+++ b/server/src/controllers/rsvpController.ts
@@ -1,5 +1,5 @@
 import { Request, Response } from "express";
-import { deleteRsvpById, rsvpToEventService, updateRsvpByToken } from "../services/rsvp";
+import { deleteRsvpById, rsvpToEventService, updateRsvpByToken, runDrawForEvent, ADMIN_PRIORITY_WEIGHT } from "../services/rsvp";
 import { getEventById as getEventByIdService } from "../services/event";
 import { isValidStatus } from "../validators/isValidStatus";
 import { getMyRsvpsService } from '../services/rsvp';
@@ -23,9 +23,15 @@ export const rsvpToEvent = async (req: Request, res: Response, next: Function) =
       return res.status(404).json({ error: "Event not found." });
     }
 
+    const isAdmin = isAdminRequest(req);
+
+    // In lottery mode the draw is the gate, so there is no registration-opening
+    // rush to enforce; sign-ups stay open through the entry window. The FIFO path
+    // keeps the existing registrationOpensAt gate.
+    const isLottery = (event as any).selection_mode === 'lottery';
     const registrationOpensAt = (event as any).registration_opens_at as string | null;
-    if (registrationOpensAt && Date.now() < new Date(registrationOpensAt).getTime() - 1000) {
-      if (!isAdminRequest(req)) {
+    if (!isLottery && registrationOpensAt && Date.now() < new Date(registrationOpensAt).getTime() - 1000) {
+      if (!isAdmin) {
         return res.status(403).json({ error: "Registration not yet open.", registrationOpensAt });
       }
     }
@@ -34,7 +40,8 @@ export const rsvpToEvent = async (req: Request, res: Response, next: Function) =
       attendeeId = require('uuid').v4();
     }
 
-    const rsvp = await rsvpToEventService({ id: attendeeId, eventId, name, status, guests });
+    const priorityWeight = isAdmin ? ADMIN_PRIORITY_WEIGHT : 0;
+    const rsvp = await rsvpToEventService({ id: attendeeId, eventId, name, status, guests, priorityWeight });
     res.status(201).json({ message: "RSVP recorded!", rsvp });
   } catch (err) {
     next(err);
@@ -78,6 +85,31 @@ export const updateRsvpByTokenController = async (req: Request, res: Response, n
   }
 };
 
+// Admin-triggered lottery draw. Assigns a position to every 'going' RSVP. Only
+// valid for lottery events, and guarded against re-running once a draw has
+// happened (so attendees who already saw they were in are not reshuffled).
+export const drawLottery = async (req: Request, res: Response, next: Function) => {
+  try {
+    const { id: eventId } = req.params;
+
+    const event = await getEventByIdService(eventId);
+    if (!event) {
+      return res.status(404).json({ error: "Event not found." });
+    }
+    if ((event as any).selection_mode !== 'lottery') {
+      return res.status(400).json({ error: "Event is not in lottery mode." });
+    }
+    if ((event as any).drawn_at) {
+      return res.status(409).json({ error: "Lottery has already been drawn for this event." });
+    }
+
+    const drawnAt = runDrawForEvent(eventId);
+    res.status(200).json({ message: "Lottery drawn!", drawnAt });
+  } catch (err) {
+    next(err);
+  }
+};
+
 export const getMyRsvps = async (req: Request, res: Response, next: Function) => {
   try {
     const pairs = req.body.myRsvps;
@@ -97,5 +129,6 @@ export const rsvpController = {
   rsvpToEvent,
   deleteRsvp,
   updateRsvpByTokenController,
+  drawLottery,
   getMyRsvps
 };

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -21,6 +21,34 @@ function migrationAddRegistrationOpensAtToEvents() {
   }
 }
 
+// Migration: Add lottery columns to events if missing
+function migrationAddLotteryColumnsToEvents() {
+  type PragmaColumn = { name: string };
+  const pragma = db.prepare("PRAGMA table_info(events);").all() as PragmaColumn[];
+  if (!pragma.some(col => col.name === 'selection_mode')) {
+    db.prepare("ALTER TABLE events ADD COLUMN selection_mode TEXT NOT NULL DEFAULT 'fifo';").run();
+    console.log("Added 'selection_mode' column to events table.");
+  }
+  if (!pragma.some(col => col.name === 'drawn_at')) {
+    db.prepare("ALTER TABLE events ADD COLUMN drawn_at TEXT;").run();
+    console.log("Added 'drawn_at' column to events table.");
+  }
+}
+
+// Migration: Add lottery columns to rsvp if missing
+function migrationAddLotteryColumnsToRsvp() {
+  type PragmaColumn = { name: string };
+  const pragma = db.prepare("PRAGMA table_info(rsvp);").all() as PragmaColumn[];
+  if (!pragma.some(col => col.name === 'priority_weight')) {
+    db.prepare("ALTER TABLE rsvp ADD COLUMN priority_weight REAL NOT NULL DEFAULT 0;").run();
+    console.log("Added 'priority_weight' column to rsvp table.");
+  }
+  if (!pragma.some(col => col.name === 'lottery_rank')) {
+    db.prepare("ALTER TABLE rsvp ADD COLUMN lottery_rank INTEGER;").run();
+    console.log("Added 'lottery_rank' column to rsvp table.");
+  }
+}
+
 // Seeds the SQLite database with required tables
 export default function seed() {
   try {
@@ -34,7 +62,9 @@ export default function seed() {
         end_time TEXT,
         max_attendees INTEGER,
         location TEXT NOT NULL,
-        created_at DATETIME NOT NULL DEFAULT (datetime('now'))
+        created_at DATETIME NOT NULL DEFAULT (datetime('now')),
+        selection_mode TEXT NOT NULL DEFAULT 'fifo',
+        drawn_at TEXT
       );
     `).run();
 
@@ -49,6 +79,8 @@ export default function seed() {
         created_at DATETIME NOT NULL DEFAULT (datetime('now')),
         updated_at DATETIME NOT NULL DEFAULT (datetime('now')),
         token TEXT NOT NULL DEFAULT 'legacy',
+        priority_weight REAL NOT NULL DEFAULT 0,
+        lottery_rank INTEGER,
         UNIQUE(event_id, id),
         FOREIGN KEY(event_id) REFERENCES events(id) ON DELETE CASCADE
       );
@@ -56,6 +88,8 @@ export default function seed() {
 
     migrationAddTokenColumnToRsvp();
     migrationAddRegistrationOpensAtToEvents();
+    migrationAddLotteryColumnsToEvents();
+    migrationAddLotteryColumnsToRsvp();
 
     // Create polls table
     db.prepare(`

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -13,6 +13,7 @@ router.get("/admin/events", authenticateAdmin, eventController.getAllEvents);
 router.patch("/admin/events/:id", authenticateAdmin, eventController.updateEvent);
 router.delete("/admin/events/:id", authenticateAdmin, eventController.deleteEvent);
 router.delete("/admin/events/rsvp/:id", authenticateAdmin, rsvpController.deleteRsvp);
+router.post("/admin/events/:id/draw", authenticateAdmin, rsvpController.drawLottery);
 router.post("/admin/events/:id/poll", authenticateAdmin, pollController.createPollController);
 router.patch("/admin/polls/:id/close", authenticateAdmin, pollController.closePollController);
 router.patch("/admin/polls/:id/reopen", authenticateAdmin, pollController.reopenPollController);

--- a/server/src/services/event.ts
+++ b/server/src/services/event.ts
@@ -6,11 +6,11 @@ import { v4 as uuidv4 } from 'uuid';
 export function createEvent(event: Omit<Event, 'id' | 'createdAt'>): Event {
   const id = uuidv4();
   const createdAt = new Date().toISOString();
-  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = event;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt, selectionMode } = event;
   db.prepare(`
-    INSERT INTO events (id, name, date, start_time, end_time, max_attendees, location, created_at, registration_opens_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, name, date, startTime, endTime || null, maxAttendees ?? null, location, createdAt, registrationOpensAt ?? null);
+    INSERT INTO events (id, name, date, start_time, end_time, max_attendees, location, created_at, registration_opens_at, selection_mode)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, name, date, startTime, endTime || null, maxAttendees ?? null, location, createdAt, registrationOpensAt ?? null, selectionMode === 'lottery' ? 'lottery' : 'fifo');
   return db.prepare('SELECT * FROM events WHERE id = ?').get(id) as Event;
 }
 
@@ -29,7 +29,7 @@ export function deleteEvent(id: string): boolean {
 export function updateEvent(id: string, updates: Partial<Omit<Event, 'id' | 'createdAt'>>): Event | null {
   const existing = getEventById(id);
   if (!existing) return null;
-  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = updates;
+  const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt, selectionMode } = updates;
   db.prepare(`
     UPDATE events SET
       name = COALESCE(?, name),
@@ -38,7 +38,8 @@ export function updateEvent(id: string, updates: Partial<Omit<Event, 'id' | 'cre
       end_time = COALESCE(?, end_time),
       max_attendees = CASE WHEN ? = 1 THEN ? ELSE max_attendees END,
       location = COALESCE(?, location),
-      registration_opens_at = CASE WHEN ? = 1 THEN ? ELSE registration_opens_at END
+      registration_opens_at = CASE WHEN ? = 1 THEN ? ELSE registration_opens_at END,
+      selection_mode = COALESCE(?, selection_mode)
     WHERE id = ?
   `).run(
     name ?? null,
@@ -50,6 +51,7 @@ export function updateEvent(id: string, updates: Partial<Omit<Event, 'id' | 'cre
     location ?? null,
     registrationOpensAt !== undefined ? 1 : 0,
     registrationOpensAt ?? null,
+    selectionMode === undefined ? null : (selectionMode === 'lottery' ? 'lottery' : 'fifo'),
     id
   );
   return db.prepare('SELECT * FROM events WHERE id = ?').get(id) as Event;

--- a/server/src/services/rsvp.ts
+++ b/server/src/services/rsvp.ts
@@ -1,19 +1,66 @@
 import db from '../db';
 import crypto from 'crypto';
 
-export function rsvpToEventService({ id, eventId, name, status, guests = 0 }: { id: string, eventId: string, name: string, status: string, guests?: number }) {
+// Priority weight stamped on RSVPs created by an admin. A positive weight seeds
+// them ahead of regular entrants in a lottery draw. Kept as a number (not a
+// boolean) so rotation/recency weighting can reuse the same column later.
+export const ADMIN_PRIORITY_WEIGHT = 1;
+
+export function rsvpToEventService({ id, eventId, name, status, guests = 0, priorityWeight = 0 }: { id: string, eventId: string, name: string, status: string, guests?: number, priorityWeight?: number }) {
   const now = new Date().toISOString();
   const token = crypto.randomBytes(32).toString('hex');
   db.prepare(`
-    INSERT INTO rsvp (id, event_id, name, status, guests, created_at, updated_at, token)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, eventId, name, status, guests, now, now, token);
+    INSERT INTO rsvp (id, event_id, name, status, guests, created_at, updated_at, token, priority_weight)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+  `).run(id, eventId, name, status, guests, now, now, token, priorityWeight);
   return db.prepare('SELECT * FROM rsvp WHERE id = ? AND event_id = ?').get(id, eventId);
 }
 
-// Gets all RSVPs for an event, ordered by creation time ascending
+// Gets all RSVPs for an event. For a lottery event that has been drawn, RSVPs
+// are ordered by their assigned lottery_rank (entries that signed up after the
+// draw have a null rank and fall to the back in creation order). Otherwise
+// (FIFO, or a lottery not yet drawn) they are ordered by creation time ascending.
 export function getRsvpByEventId(eventId: string) {
-  return db.prepare('SELECT id, name, status, guests, created_at, updated_at FROM rsvp WHERE event_id = ? ORDER BY created_at ASC').all(eventId);
+  const event = db.prepare('SELECT selection_mode, drawn_at FROM events WHERE id = ?').get(eventId) as
+    | { selection_mode?: string; drawn_at?: string | null }
+    | undefined;
+  const isDrawnLottery = event?.selection_mode === 'lottery' && !!event?.drawn_at;
+  const orderBy = isDrawnLottery
+    ? 'ORDER BY lottery_rank IS NULL, lottery_rank ASC, created_at ASC'
+    : 'ORDER BY created_at ASC';
+  return db
+    .prepare(`SELECT id, name, status, guests, created_at, updated_at, priority_weight, lottery_rank FROM rsvp WHERE event_id = ? ${orderBy}`)
+    .all(eventId);
+}
+
+// Runs the lottery draw for an event: assigns a lottery_rank to every 'going'
+// RSVP. Entries are seeded by priority_weight (admins get a positive weight, so
+// they sort first), with ties broken randomly. The same priority_weight column
+// is intended to later carry rotation/recency weighting without a schema change.
+// Idempotency is the caller's responsibility (the controller guards re-draws).
+export function runDrawForEvent(eventId: string) {
+  const draw = db.transaction((eventId: string) => {
+    const going = db
+      .prepare("SELECT id, priority_weight FROM rsvp WHERE event_id = ? AND status = 'going'")
+      .all(eventId) as { id: string; priority_weight: number }[];
+
+    // Use a CSPRNG for the tiebreak: this is a fairness-sensitive draw, so the
+    // ordering must not be predictable/riggable by a participant. crypto.randomInt
+    // caps its range at 2^48, which is ample entropy to break ties without
+    // realistic collisions for any plausible attendee count.
+    const RANDOM_KEY_BOUND = 2 ** 48 - 1;
+    const ordered = going
+      .map((r) => ({ id: r.id, weight: r.priority_weight ?? 0, key: crypto.randomInt(0, RANDOM_KEY_BOUND) }))
+      .sort((a, b) => b.weight - a.weight || a.key - b.key);
+
+    const setRank = db.prepare('UPDATE rsvp SET lottery_rank = ? WHERE id = ? AND event_id = ?');
+    ordered.forEach((r, index) => setRank.run(index + 1, r.id, eventId));
+
+    const drawnAt = new Date().toISOString();
+    db.prepare('UPDATE events SET drawn_at = ? WHERE id = ?').run(drawnAt, eventId);
+    return drawnAt;
+  });
+  return draw(eventId);
 }
 
 // Deletes an RSVP by id
@@ -29,9 +76,15 @@ export function updateRsvpByToken({ eventId, rsvpId, token, name, status, guests
   status: string,
   guests: number
 }) {
-  const sql = `UPDATE rsvp SET name = ?, status = ?, guests = ?, updated_at = ? WHERE id = ? AND event_id = ? AND token = ?`;
+  // Changing away from 'going' after a lottery draw forfeits the drawn seat: the
+  // rank is cleared, so rejoining later puts the entrant at the back rather than
+  // reclaiming a spot that may have already been promoted to a waitlister. An
+  // edit that stays 'going' (e.g. changing the guest count) keeps the rank, so it
+  // never demotes someone who still holds their place. No-op for un-drawn/FIFO
+  // events, where lottery_rank is already null.
+  const sql = `UPDATE rsvp SET name = ?, status = ?, guests = ?, updated_at = ?, lottery_rank = CASE WHEN ? = 'going' THEN lottery_rank ELSE NULL END WHERE id = ? AND event_id = ? AND token = ?`;
   const now = new Date().toISOString();
-  const result = db.prepare(sql).run(name, status, guests, now, rsvpId, eventId, token);
+  const result = db.prepare(sql).run(name, status, guests, now, status, rsvpId, eventId, token);
   if (result.changes === 0) return null;
   return db.prepare('SELECT * FROM rsvp WHERE id = ? AND event_id = ?').get(rsvpId, eventId);
 }

--- a/server/src/types/Event.ts
+++ b/server/src/types/Event.ts
@@ -8,5 +8,7 @@ export type Event = {
   location: string;
   createdAt?: string; // ISO date string (YYYY-MM-DDTHH:mm:ss.sssZ)
   registrationOpensAt?: string; // ISO UTC datetime — when public registration opens
+  selectionMode?: 'fifo' | 'lottery'; // how seats are allocated; defaults to 'fifo'
+  drawnAt?: string; // ISO UTC datetime — when the lottery draw was run (lottery mode only)
 };
 

--- a/server/src/types/Rsvp.ts
+++ b/server/src/types/Rsvp.ts
@@ -6,6 +6,8 @@ export type Rsvp = {
   created_at?: string; // ISO date string
   updated_at?: string; // ISO date string
   guests?: number;
-  token: string
+  token: string;
+  priority_weight?: number; // higher = seeded earlier in a lottery draw (admins > 0)
+  lottery_rank?: number | null; // assigned position after a draw; null until drawn
 }
 


### PR DESCRIPTION
Events can now allocate seats by a random lottery draw as an alternative to first-come-first-served, selectable at creation and editable later.

Server:
- selection_mode/drawn_at on events; priority_weight/lottery_rank on rsvp
- admin-only POST /admin/events/:id/draw, guarded against re-running
- draw seeds by priority_weight then a CSPRNG tiebreak; admins are stamped a priority weight at sign-up so they sort ahead of regular entrants
- lottery sign-ups skip the registration-opens-at gate (the draw is the gate)
- post-draw and maybe->going entrants fall to the back; leaving 'going' forfeits a drawn rank so a promoted waitlister keeps their seat

Client:
- seat-allocation select on create/edit forms
- admin "Run the draw" button and lottery status banner on the event page
- pre-draw lottery shows a single "In the draw (N for M seats)" list instead of a misleading Going/Waitlist split
- lottery sign-ups are not gated by registration_opens_at on the client either, matching the server: no countdown, the form stays open
- priority badge in the attendee list, shown only for lottery events (admins are stamped a weight on every sign-up, but it is meaningless under FIFO)
- sign-ups send admin credentials when logged in so the server can stamp priority