### PR TITLE
Add optional max votes limit to polls

### DIFF
--- a/client/e2e/poll-vote-limit.spec.ts
+++ b/client/e2e/poll-vote-limit.spec.ts
@@ -1,0 +1,82 @@
+import { expect, test } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+// Creates an event with one RSVP and a poll that limits each voter to `maxVotes`
+// selections across three options (Chips, Pretzels, Popcorn).
+async function setupLimitedPoll(request: any, maxVotes: number) {
+  const eventRes = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'Poll Vote Limit Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue',
+    },
+  });
+  const eventId = (await eventRes.json()).event.id as string;
+
+  const rsvpRes = await request.post(`${API}/events/${eventId}/rsvp`, {
+    data: { name: 'Limit Tester', status: 'going' },
+  });
+  const { rsvp } = await rsvpRes.json();
+
+  const pollRes = await request.post(`${API}/admin/events/${eventId}/poll`, {
+    headers: { Authorization: AUTH },
+    data: {
+      title: 'Favourite Snack',
+      maxVotes,
+      options: [
+        { name: 'Chips', url: 'https://example.com/chips' },
+        { name: 'Pretzels', url: 'https://example.com/pretzels' },
+        { name: 'Popcorn', url: 'https://example.com/popcorn' },
+      ],
+    },
+  });
+  const pollId = (await pollRes.json()).poll.id as string;
+
+  return { eventId, rsvpId: rsvp.id as string, token: rsvp.token as string, pollId };
+}
+
+test.describe('Poll vote limit', () => {
+  test('user cannot select more options than the poll allows', async ({ page, request }) => {
+    const { eventId, rsvpId, token } = await setupLimitedPoll(request, 2);
+
+    await page.addInitScript(
+      ({ eventId, rsvpId, token }: { eventId: string; rsvpId: string; token: string }) => {
+        localStorage.setItem('my_events', JSON.stringify({ [eventId]: { [rsvpId]: token } }));
+      },
+      { eventId, rsvpId, token }
+    );
+
+    await page.goto(`/events/${eventId}`);
+
+    // Hint reflects the limit and starts at zero selected.
+    await expect(page.getByText('Select up to 2 options. (0 selected)')).toBeVisible();
+
+    const chips = page.locator('li').filter({ hasText: 'Chips' });
+    const pretzels = page.locator('li').filter({ hasText: 'Pretzels' });
+    const popcorn = page.locator('li').filter({ hasText: 'Popcorn' });
+
+    // Select the two allowed options.
+    await chips.locator('input[type="checkbox"]').check();
+    await pretzels.locator('input[type="checkbox"]').check();
+    await expect(page.getByText('Select up to 2 options. (2 selected)')).toBeVisible();
+
+    // At the limit, the third option is disabled and cannot be selected.
+    await expect(popcorn.locator('input[type="checkbox"]')).toBeDisabled();
+
+    // Saving stores exactly the two selected votes.
+    await page.getByRole('button', { name: 'Save vote' }).click();
+    await expect(page.getByText('Vote saved!')).toBeVisible();
+    await expect(chips.getByText('1 vote')).toBeVisible();
+    await expect(pretzels.getByText('1 vote')).toBeVisible();
+    await expect(popcorn.getByText('0 votes')).toBeVisible();
+
+    // Deselecting one option re-enables the disabled option.
+    await chips.locator('input[type="checkbox"]').uncheck();
+    await expect(popcorn.locator('input[type="checkbox"]')).toBeEnabled();
+  });
+});

--- a/client/e2e/poll-vote-limit.spec.ts
+++ b/client/e2e/poll-vote-limit.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -51,7 +52,7 @@ test.describe('Poll vote limit', () => {
       { eventId, rsvpId, token }
     );
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // Hint reflects the limit and starts at zero selected.
     await expect(page.getByText('Select up to 2 options. (0 selected)')).toBeVisible();

--- a/client/src/__tests__/components/PollWidget.test.ts
+++ b/client/src/__tests__/components/PollWidget.test.ts
@@ -11,6 +11,7 @@ const openPoll: Poll = {
   event_id: 'evt-1',
   title: 'Vote for tonight\'s script',
   status: 'open',
+  max_votes: null,
   created_at: '2024-01-01T00:00:00.000Z',
   options: [
     {
@@ -230,6 +231,55 @@ describe('PollWidget — open poll', () => {
       props: { poll: openPoll, user: undefined, isAdmin: false, eventId: 'evt-1' },
     });
     expect(screen.getByText('A description')).toBeInTheDocument();
+  });
+});
+
+describe('PollWidget — max votes limit', () => {
+  const limitedPoll: Poll = { ...openPoll, max_votes: 1 };
+
+  it('shows a "Select up to N" hint when a limit is set and the user is logged in', () => {
+    render(PollWidget, {
+      props: { poll: limitedPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText(/Select up to 1 option\./)).toBeInTheDocument();
+  });
+
+  it('does not show the hint when there is no limit', () => {
+    render(PollWidget, {
+      props: { poll: openPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.queryByText(/Select up to/)).not.toBeInTheDocument();
+  });
+
+  it('disables unselected checkboxes once the limit is reached', async () => {
+    // limitedPoll allows 1 vote; opt-2 is already selected (rsvp-x voted for it).
+    render(PollWidget, {
+      props: { poll: limitedPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    const [cbA, cbB] = screen.getAllByRole('checkbox');
+    expect(cbB).toBeChecked();
+    // At the limit, the unselected option is disabled and cannot be added.
+    expect(cbA).toBeDisabled();
+  });
+
+  it('reflects the selected count in the hint and frees up slots when deselecting', async () => {
+    render(PollWidget, {
+      props: { poll: limitedPoll, user: loggedInUser, isAdmin: false, eventId: 'evt-1' },
+    });
+    expect(screen.getByText(/\(1 selected\)/)).toBeInTheDocument();
+    const [cbA, cbB] = screen.getAllByRole('checkbox');
+    // Deselect opt-2, which should re-enable opt-1.
+    await fireEvent.change(cbB);
+    expect(screen.getByText(/\(0 selected\)/)).toBeInTheDocument();
+    expect(cbA).not.toBeDisabled();
+  });
+
+  it('pre-fills the max votes field in the edit form', async () => {
+    render(PollWidget, {
+      props: { poll: limitedPoll, user: undefined, isAdmin: true, eventId: 'evt-1' },
+    });
+    await fireEvent.click(screen.getByRole('button', { name: 'Edit' }));
+    expect(screen.getByLabelText('Max votes per person')).toHaveValue(1);
   });
 });
 

--- a/client/src/lib/PollWidget.svelte
+++ b/client/src/lib/PollWidget.svelte
@@ -21,6 +21,7 @@
   // Admin create form state
   let showCreateForm = false;
   let newTitle = '';
+  let newMaxVotes: number | null = null;
   let newOptions: { name: string; url: string; description: string }[] = [
     { name: '', url: '', description: '' },
   ];
@@ -30,9 +31,20 @@
   // Admin edit form state
   let showEditForm = false;
   let editTitle = '';
+  let editMaxVotes: number | null = null;
   let editOptions: { id?: string; name: string; url: string; description: string }[] = [];
   let editLoading = false;
   let editError = '';
+
+  // Number of options a voter may select (null = no limit).
+  $: voteLimit = currentPoll?.max_votes ?? null;
+
+  // Normalizes a max-votes form field into a payload value. A number input binds to a
+  // number (or null when empty); an empty string is also treated as "no limit" (null).
+  function normalizeMaxVotes(raw: number | string | null | undefined): number | null {
+    if (raw === null || raw === undefined || raw === '') return null;
+    return Number(raw);
+  }
 
   // Initialize selections from server state when poll or user changes
   function initSelectedOptions(p: Poll | null, u: User | undefined) {
@@ -53,6 +65,8 @@
     if (next.has(optId)) {
       next.delete(optId);
     } else {
+      // Enforce the per-voter limit client-side; the server enforces it too.
+      if (voteLimit != null && next.size >= voteLimit) return;
       next.add(optId);
     }
     selectedOptionIds = next;
@@ -110,6 +124,7 @@
   function enterEditMode() {
     if (!currentPoll) return;
     editTitle = currentPoll.title;
+    editMaxVotes = currentPoll.max_votes;
     editOptions = currentPoll.options.map(o => ({
       id: o.id,
       name: o.name,
@@ -134,13 +149,18 @@
       editError = 'A title and at least one option with name and URL are required.';
       return;
     }
+    const maxVotes = normalizeMaxVotes(editMaxVotes);
+    if (maxVotes != null && (!Number.isInteger(maxVotes) || maxVotes < 1)) {
+      editError = 'Max votes must be a whole number of at least 1, or left blank for no limit.';
+      return;
+    }
     editLoading = true;
     editError = '';
     try {
       const res = await adminFetch(`${API_HOST}/admin/polls/${currentPoll!.id}`, {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: editTitle, options: validOptions }),
+        body: JSON.stringify({ title: editTitle, options: validOptions, maxVotes }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -173,13 +193,18 @@
       createError = 'A title and at least one option with name and URL are required.';
       return;
     }
+    const maxVotes = normalizeMaxVotes(newMaxVotes);
+    if (maxVotes != null && (!Number.isInteger(maxVotes) || maxVotes < 1)) {
+      createError = 'Max votes must be a whole number of at least 1, or left blank for no limit.';
+      return;
+    }
     createLoading = true;
     createError = '';
     try {
       const res = await adminFetch(`${API_HOST}/admin/events/${eventId}/poll`, {
         method: 'POST',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({ title: newTitle, options: validOptions }),
+        body: JSON.stringify({ title: newTitle, options: validOptions, maxVotes }),
       });
       const data = await res.json();
       if (!res.ok) {
@@ -188,6 +213,7 @@
         currentPoll = data.poll;
         showCreateForm = false;
         newTitle = '';
+        newMaxVotes = null;
         newOptions = [{ name: '', url: '', description: '' }];
       }
     } catch {
@@ -227,6 +253,19 @@
               type="text"
               bind:value={newTitle}
               placeholder="e.g. Vote for tonight's scripts"
+              class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+            />
+          </div>
+
+          <div class="mb-3">
+            <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" for="new-poll-max-votes">Max votes per person</label>
+            <input
+              id="new-poll-max-votes"
+              type="number"
+              min="1"
+              step="1"
+              bind:value={newMaxVotes}
+              placeholder="Leave blank for no limit"
               class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
             />
           </div>
@@ -363,6 +402,19 @@
         />
       </div>
 
+      <div class="mb-3">
+        <label class="block text-sm font-medium text-gray-700 dark:text-gray-300 mb-1" for="edit-poll-max-votes">Max votes per person</label>
+        <input
+          id="edit-poll-max-votes"
+          type="number"
+          min="1"
+          step="1"
+          bind:value={editMaxVotes}
+          placeholder="Leave blank for no limit"
+          class="w-full rounded border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-900 text-gray-900 dark:text-gray-100 px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-primary"
+        />
+      </div>
+
       <div class="mb-3 space-y-2">
         <p class="text-sm font-medium text-gray-700 dark:text-gray-300">Options</p>
         {#each editOptions as opt, i}
@@ -481,6 +533,10 @@
         <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
           RSVP first to participate in the vote.
         </p>
+      {:else if voteLimit != null}
+        <p class="text-sm text-gray-500 dark:text-gray-400 mb-2">
+          Select up to {voteLimit} option{voteLimit !== 1 ? 's' : ''}. ({selectedOptionIds.size} selected)
+        </p>
       {/if}
 
       <ul class="space-y-2">
@@ -490,10 +546,12 @@
             {user ? 'hover:border-primary transition-colors' : ''}
             {isSelected ? 'border-primary bg-blue-50 dark:bg-blue-900/20' : ''}">
             {#if user}
-              <label class="flex items-start gap-3 cursor-pointer">
+              {@const isDisabled = !isSelected && voteLimit != null && selectedOptionIds.size >= voteLimit}
+              <label class="flex items-start gap-3 {isDisabled ? 'cursor-not-allowed opacity-60' : 'cursor-pointer'}">
                 <input
                   type="checkbox"
                   checked={isSelected}
+                  disabled={isDisabled}
                   on:change={() => toggleOption(opt.id)}
                   class="mt-1 accent-primary shrink-0"
                 />

--- a/client/src/types/Poll.ts
+++ b/client/src/types/Poll.ts
@@ -18,6 +18,7 @@ export type Poll = {
   event_id: string;
   title: string;
   status: 'open' | 'closed';
+  max_votes: number | null;
   created_at: string;
   options: PollOption[];
 };

--- a/server/src/__tests__/integration/polls.test.ts
+++ b/server/src/__tests__/integration/polls.test.ts
@@ -51,6 +51,29 @@ describe('POST /admin/events/:id/poll', () => {
       .expect(201);
     expect(res.body.poll.status).toBe('open');
     expect(res.body.poll.options).toHaveLength(2);
+    expect(res.body.poll.max_votes).toBeNull();
+  });
+
+  it('creates a poll with a max_votes limit', async () => {
+    const res = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS, maxVotes: 1 })
+      .expect(201);
+    expect(res.body.poll.max_votes).toBe(1);
+  });
+
+  it('returns 400 when maxVotes is not a positive integer', async () => {
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS, maxVotes: 0 })
+      .expect(400);
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS, maxVotes: 1.5 })
+      .expect(400);
   });
 
   it('returns 400 when title is missing', async () => {
@@ -287,6 +310,24 @@ describe('POST /polls/:id/vote', () => {
       .post(`/polls/${pollId}/vote`)
       .send({ rsvpId, token: 'wrongtoken', optionIds: [created.body.poll.options[0].id] })
       .expect(403);
+  });
+
+  it('returns 400 when voting for more options than max_votes allows', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS, maxVotes: 1 });
+    const poll = created.body.poll;
+
+    const res = await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: poll.options.map((o: any) => o.id) })
+      .expect(400);
+    expect(res.body.error).toMatch(/at most 1 option/);
+
+    // No votes should have been recorded.
+    const after = await request(server).get(`/events/${eventId}`);
+    expect(after.body.poll.options.every((o: any) => o.votes.length === 0)).toBe(true);
   });
 
   it('returns 400 when required fields are missing', async () => {

--- a/server/src/__tests__/unit/services/pollService.test.ts
+++ b/server/src/__tests__/unit/services/pollService.test.ts
@@ -8,6 +8,7 @@ import {
   getPollByEventId,
   reopenPoll,
   updatePoll,
+  VoteLimitError,
 } from '../../../services/poll';
 import { createEvent } from '../../../services/event';
 import { rsvpToEventService } from '../../../services/rsvp';
@@ -78,6 +79,16 @@ describe('createPoll', () => {
       { name: 'A', url: 'https://a.example.com', description: 'Nice place' },
     ]);
     expect(poll.options[0].description).toBe('Nice place');
+  });
+
+  it('defaults max_votes to null (no limit)', () => {
+    const poll = createPoll(eventId, 'When?', TWO_OPTIONS);
+    expect(poll.max_votes).toBeNull();
+  });
+
+  it('stores an optional max_votes limit', () => {
+    const poll = createPoll(eventId, 'When?', TWO_OPTIONS, 1);
+    expect(poll.max_votes).toBe(1);
   });
 
   it('does NOT prevent a second poll for the same event (BUG: duplicate polls)', () => {
@@ -164,6 +175,20 @@ describe('updatePoll', () => {
   it('returns null for an unknown poll id', () => {
     expect(updatePoll('ghost', 'Title', [{ name: 'x', url: 'x' }])).toBeNull();
   });
+
+  it('updates the max_votes limit', () => {
+    const poll = createPoll(eventId, 'Where?', TWO_OPTIONS, 1);
+    const existing = poll.options.map((o) => ({ id: o.id, name: o.name, url: o.url }));
+    const updated = updatePoll(poll.id, 'Where?', existing, 2)!;
+    expect(updated.max_votes).toBe(2);
+  });
+
+  it('clears the max_votes limit when omitted', () => {
+    const poll = createPoll(eventId, 'Where?', TWO_OPTIONS, 1);
+    const existing = poll.options.map((o) => ({ id: o.id, name: o.name, url: o.url }));
+    const updated = updatePoll(poll.id, 'Where?', existing)!;
+    expect(updated.max_votes).toBeNull();
+  });
 });
 
 describe('deletePoll', () => {
@@ -234,5 +259,30 @@ describe('castVotes', () => {
     const otherPoll = createPoll(otherEventId, 'Other', TWO_OPTIONS);
     const poll = createPoll(eventId, 'Vote', TWO_OPTIONS);
     expect(castVotes(poll.id, rsvpId, rsvpToken, [otherPoll.options[0].id])).toBeNull();
+  });
+
+  it('allows voting up to the max_votes limit', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS, 1);
+    const result = castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id])!;
+    expect(result.options[0].votes).toHaveLength(1);
+  });
+
+  it('throws VoteLimitError when more options than max_votes are selected', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS, 1);
+    expect(() =>
+      castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id, poll.options[1].id]),
+    ).toThrow(VoteLimitError);
+  });
+
+  it('does not record any votes when the limit is exceeded', () => {
+    const poll = createPoll(eventId, 'Vote', TWO_OPTIONS, 1);
+    try {
+      castVotes(poll.id, rsvpId, rsvpToken, [poll.options[0].id, poll.options[1].id]);
+    } catch {
+      // expected
+    }
+    const after = getPollByEventId(eventId)!;
+    expect(after.options[0].votes).toHaveLength(0);
+    expect(after.options[1].votes).toHaveLength(0);
   });
 });

--- a/server/src/controllers/pollController.ts
+++ b/server/src/controllers/pollController.ts
@@ -1,10 +1,20 @@
 import { Request, Response } from 'express';
-import { createPoll, closePoll, reopenPoll, updatePoll, deletePoll, castVotes } from '../services/poll';
+import { createPoll, closePoll, reopenPoll, updatePoll, deletePoll, castVotes, VoteLimitError } from '../services/poll';
+
+// Validates an optional max-votes value from a request body.
+// Returns { value } on success (null means "no limit") or { error } when invalid.
+function parseMaxVotes(raw: unknown): { value: number | null } | { error: string } {
+  if (raw === undefined || raw === null) return { value: null };
+  if (typeof raw !== 'number' || !Number.isInteger(raw) || raw < 1) {
+    return { error: 'maxVotes must be a positive integer when provided.' };
+  }
+  return { value: raw };
+}
 
 export const createPollController = async (req: Request, res: Response, next: Function) => {
   try {
     const { id: eventId } = req.params;
-    const { title, options } = req.body;
+    const { title, options, maxVotes } = req.body;
 
     if (!title || !Array.isArray(options) || options.length === 0) {
       return res.status(400).json({ error: 'Title and at least one option are required.' });
@@ -16,7 +26,12 @@ export const createPollController = async (req: Request, res: Response, next: Fu
       }
     }
 
-    const poll = createPoll(eventId, title, options);
+    const parsedMaxVotes = parseMaxVotes(maxVotes);
+    if ('error' in parsedMaxVotes) {
+      return res.status(400).json({ error: parsedMaxVotes.error });
+    }
+
+    const poll = createPoll(eventId, title, options, parsedMaxVotes.value);
     res.status(201).json({ poll });
   } catch (err) {
     next(err);
@@ -52,7 +67,7 @@ export const reopenPollController = async (req: Request, res: Response, next: Fu
 export const updatePollController = async (req: Request, res: Response, next: Function) => {
   try {
     const { id: pollId } = req.params;
-    const { title, options } = req.body;
+    const { title, options, maxVotes } = req.body;
 
     if (!title || !Array.isArray(options) || options.length === 0) {
       return res.status(400).json({ error: 'Title and at least one option are required.' });
@@ -64,7 +79,12 @@ export const updatePollController = async (req: Request, res: Response, next: Fu
       }
     }
 
-    const poll = updatePoll(pollId, title, options);
+    const parsedMaxVotes = parseMaxVotes(maxVotes);
+    if ('error' in parsedMaxVotes) {
+      return res.status(400).json({ error: parsedMaxVotes.error });
+    }
+
+    const poll = updatePoll(pollId, title, options, parsedMaxVotes.value);
     if (!poll) {
       return res.status(404).json({ error: 'Poll not found.' });
     }
@@ -102,6 +122,9 @@ export const castVotesController = async (req: Request, res: Response, next: Fun
     }
     res.status(200).json({ poll });
   } catch (err) {
+    if (err instanceof VoteLimitError) {
+      return res.status(400).json({ error: err.message });
+    }
     next(err);
   }
 };

--- a/server/src/db/seed.ts
+++ b/server/src/db/seed.ts
@@ -21,6 +21,16 @@ function migrationAddRegistrationOpensAtToEvents() {
   }
 }
 
+// Migration: Add max_votes column to polls if missing
+function migrationAddMaxVotesToPolls() {
+  type PragmaColumn = { name: string };
+  const pragma = db.prepare("PRAGMA table_info(polls);").all() as PragmaColumn[];
+  if (!pragma.some(col => col.name === 'max_votes')) {
+    db.prepare("ALTER TABLE polls ADD COLUMN max_votes INTEGER;").run();
+    console.log("Added 'max_votes' column to polls table.");
+  }
+}
+
 // Seeds the SQLite database with required tables
 export default function seed() {
   try {
@@ -64,10 +74,13 @@ export default function seed() {
         event_id TEXT NOT NULL,
         title TEXT NOT NULL,
         status TEXT NOT NULL DEFAULT 'open',
+        max_votes INTEGER,
         created_at DATETIME NOT NULL DEFAULT (datetime('now')),
         FOREIGN KEY(event_id) REFERENCES events(id) ON DELETE CASCADE
       );
     `).run();
+
+    migrationAddMaxVotesToPolls();
 
     // Create poll_options table
     db.prepare(`

--- a/server/src/services/poll.ts
+++ b/server/src/services/poll.ts
@@ -2,9 +2,17 @@ import db from '../db';
 import { v4 as uuidv4 } from 'uuid';
 import { Poll, PollOption } from '../types/Poll';
 
-type RawPoll = { id: string; event_id: string; title: string; status: string; created_at: string };
+type RawPoll = { id: string; event_id: string; title: string; status: string; max_votes: number | null; created_at: string };
 type RawOption = { id: string; poll_id: string; name: string; url: string; description: string | null; created_at: string };
 type RawVote = { rsvp_id: string; voter_name: string };
+
+// Thrown by castVotes when a voter selects more options than the poll's max_votes allows.
+export class VoteLimitError extends Error {
+  constructor(public readonly maxVotes: number) {
+    super(`You can vote for at most ${maxVotes} option${maxVotes === 1 ? '' : 's'}.`);
+    this.name = 'VoteLimitError';
+  }
+}
 
 function buildPoll(raw: RawPoll): Poll {
   const options = db.prepare(
@@ -25,7 +33,12 @@ function buildPoll(raw: RawPoll): Poll {
     optionsWithVotes.sort((a, b) => b.votes.length - a.votes.length);
   }
 
-  return { ...raw, status: raw.status as 'open' | 'closed', options: optionsWithVotes };
+  return {
+    ...raw,
+    status: raw.status as 'open' | 'closed',
+    max_votes: raw.max_votes ?? null,
+    options: optionsWithVotes,
+  };
 }
 
 export function getPollByEventId(eventId: string): Poll | null {
@@ -37,15 +50,16 @@ export function getPollByEventId(eventId: string): Poll | null {
 export function createPoll(
   eventId: string,
   title: string,
-  options: { name: string; url: string; description?: string }[]
+  options: { name: string; url: string; description?: string }[],
+  maxVotes: number | null = null
 ): Poll {
   const pollId = uuidv4();
   const now = new Date().toISOString();
 
   const run = db.transaction(() => {
     db.prepare(
-      `INSERT INTO polls (id, event_id, title, status, created_at) VALUES (?, ?, ?, 'open', ?)`
-    ).run(pollId, eventId, title, now);
+      `INSERT INTO polls (id, event_id, title, status, max_votes, created_at) VALUES (?, ?, ?, 'open', ?, ?)`
+    ).run(pollId, eventId, title, maxVotes, now);
 
     for (const opt of options) {
       db.prepare(
@@ -73,7 +87,8 @@ export function reopenPoll(pollId: string): Poll | null {
 export function updatePoll(
   pollId: string,
   title: string,
-  options: { id?: string; name: string; url: string; description?: string }[]
+  options: { id?: string; name: string; url: string; description?: string }[],
+  maxVotes: number | null = null
 ): Poll | null {
   const poll = db.prepare('SELECT * FROM polls WHERE id = ?').get(pollId) as RawPoll | undefined;
   if (!poll) return null;
@@ -81,7 +96,7 @@ export function updatePoll(
   const now = new Date().toISOString();
 
   const run = db.transaction(() => {
-    db.prepare('UPDATE polls SET title = ? WHERE id = ?').run(title, pollId);
+    db.prepare('UPDATE polls SET title = ?, max_votes = ? WHERE id = ?').run(title, maxVotes, pollId);
 
     const currentOptions = db.prepare('SELECT id FROM poll_options WHERE poll_id = ?').all(pollId) as { id: string }[];
     const currentIds = new Set(currentOptions.map(o => o.id));
@@ -128,6 +143,10 @@ export function castVotes(
   const allOptions = db.prepare('SELECT id FROM poll_options WHERE poll_id = ?').all(pollId) as { id: string }[];
   const validIds = new Set(allOptions.map(o => o.id));
   if (!optionIds.every(id => validIds.has(id))) return null;
+
+  if (poll.max_votes != null && optionIds.length > poll.max_votes) {
+    throw new VoteLimitError(poll.max_votes);
+  }
 
   const allOptionIds = allOptions.map(o => o.id);
   const now = new Date().toISOString();

--- a/server/src/types/Poll.ts
+++ b/server/src/types/Poll.ts
@@ -13,6 +13,7 @@ export type Poll = {
   event_id: string;
   title: string;
   status: 'open' | 'closed';
+  max_votes: number | null;
   created_at: string;
   options: PollOption[];
 };


### PR DESCRIPTION
Polls can now carry an optional max_votes limit capping how many options each voter may select. Null means no limit.

- Add nullable max_votes column to polls (with migration)
- Thread max_votes through the poll type, service, and controller; validate it on create/update and enforce it in castVotes via a VoteLimitError mapped to a 400
- Add a max-votes field to the admin create/edit forms and disable unselected options once a voter reaches the limit