### PR TITLE
Reduce server calls on event detail page

### DIFF
--- a/client/src/__tests__/routes/EventDetailPage.test.ts
+++ b/client/src/__tests__/routes/EventDetailPage.test.ts
@@ -458,13 +458,20 @@ describe('EventDetailPage — registration opens in future', () => {
     const futureDate = new Date(Date.now() + 3_600_000).toISOString();
     const event: Event = { ...baseEvent, registration_opens_at: futureDate };
     const restoreIntl = stubDurationFormat();
-    stubFetchUnauthorized();
+    // Credentials stored, so the admin probe runs and startCountdown is deferred
+    // to its .finally(). That deferral is the window where the box could render
+    // blank; without credentials the countdown is computed synchronously during
+    // mount and there is no window to test.
+    localStorage.setItem('credentials', 'admin:secret');
+    vi.stubGlobal(
+      'fetch',
+      vi.fn().mockResolvedValue({ ok: false, status: 401, json: async () => ({}) } as Response),
+    );
 
     render(EventDetailPage, { props: { data: buildData(event) } });
 
-    // On the very first paint the countdown has not been computed yet. The box
-    // must stay hidden rather than render "Registration opens in" with a blank
-    // value, which is the flicker this guards against.
+    // The countdown has not been computed yet. The box must stay hidden rather
+    // than render "Registration opens in" with a blank value.
     expect(screen.queryByText(/Registration opens in/)).not.toBeInTheDocument();
 
     await waitFor(() => {
@@ -517,7 +524,9 @@ describe('EventDetailPage — registration opens in future', () => {
     const futureDate = new Date(Date.now() + 3_600_000).toISOString();
     const event: Event = { ...baseEvent, registration_opens_at: futureDate };
     const restoreIntl = stubDurationFormat();
-    // ok:true makes the admin login check succeed, so isAdmin becomes true.
+    // The admin probe only fires when credentials are stored; ok:true then makes
+    // it succeed, so isAdmin becomes true.
+    localStorage.setItem('credentials', 'admin:secret');
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({ ok: true, status: 200, json: async () => ({}) } as Response),

--- a/client/src/__tests__/routes/EventDetailPage.test.ts
+++ b/client/src/__tests__/routes/EventDetailPage.test.ts
@@ -35,16 +35,8 @@ function buildData(
 }
 
 function stubFetchUnauthorized() {
-  // removeStaleLocalStorageEntries returns early when localStorage is empty.
-  // The only fetch that fires is the admin login check; return 401 so isAdmin=false.
-  vi.stubGlobal(
-    'fetch',
-    vi.fn().mockResolvedValue({
-      ok: false,
-      status: 401,
-      json: async () => ({}),
-    } as Response),
-  );
+  // No credentials in localStorage → admin login probe is skipped entirely.
+  vi.stubGlobal('fetch', vi.fn());
 }
 
 // Intl.DurationFormat is not available in every jsdom version; return a fixed
@@ -204,6 +196,7 @@ describe('EventDetailPage — waitlist', () => {
 
 describe('EventDetailPage — admin view', () => {
   it('shows admin edit link when user is admin', async () => {
+    localStorage.setItem('credentials', 'admin:secret');
     vi.stubGlobal(
       'fetch',
       vi.fn().mockResolvedValue({
@@ -267,8 +260,8 @@ describe('EventDetailPage — +1 button', () => {
     ];
     render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
     await screen.findByRole('button', { name: /Bringing a \+1/ });
-    // Drain onMount's promise chain (fetch → attendeeName = 'Alice') before clicking,
-    // matching real-world timing where onMount completes before any user interaction.
+    // Drain onMount before clicking, matching real-world timing where onMount
+    // completes before any user interaction.
     await new Promise(resolve => setTimeout(resolve, 0));
     await fireEvent.click(screen.getByRole('button', { name: /Bringing a \+1/ }));
     expect(screen.getByPlaceholderText('Enter your name')).toHaveValue('');
@@ -389,6 +382,51 @@ describe('EventDetailPage — XSS safety', () => {
   });
 });
 
+describe('EventDetailPage — server call reduction', () => {
+  it('does not fire the admin login probe when no credentials are stored', async () => {
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    render(EventDetailPage, { props: { data: buildData() } });
+    // Drain onMount's synchronous body and any microtasks.
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+
+  it('fires the admin login probe exactly once when credentials are stored', async () => {
+    localStorage.setItem('credentials', 'admin:secret');
+    const fetchSpy = vi.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      json: async () => ({}),
+    } as Response);
+    vi.stubGlobal('fetch', fetchSpy);
+    render(EventDetailPage, { props: { data: buildData() } });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect(String(fetchSpy.mock.calls[0][0])).toContain('/admin/login');
+  });
+
+  it('prunes stale localStorage RSVP entries absent from the loaded attendees', async () => {
+    // 'stale' is not in the loaded attendees, so it should be pruned; 'r1' stays.
+    localStorage.setItem(
+      'my_events',
+      JSON.stringify({ 'evt-1': { 'r1': 'tok1', 'stale': 'tok2' } }),
+    );
+    const rsvps: Rsvp[] = [
+      { id: 'r1', name: 'Alice', event_id: 'evt-1', status: 'going', guests: 0, token: 'tok1' },
+    ];
+    const fetchSpy = vi.fn();
+    vi.stubGlobal('fetch', fetchSpy);
+    render(EventDetailPage, { props: { data: buildData(baseEvent, rsvps) } });
+    await new Promise(resolve => setTimeout(resolve, 0));
+    const stored = JSON.parse(localStorage.getItem('my_events') ?? '{}');
+    expect(stored['evt-1']).toHaveProperty('r1');
+    expect(stored['evt-1']).not.toHaveProperty('stale');
+    // Pruning must rely on the already-loaded attendees, not a fresh fetch.
+    expect(fetchSpy).not.toHaveBeenCalled();
+  });
+});
+
 describe('EventDetailPage — registration opens in future', () => {
   it('shows a countdown when registration is not yet open', async () => {
     const futureDate = new Date(Date.now() + 3_600_000).toISOString();
@@ -405,14 +443,7 @@ describe('EventDetailPage — registration opens in future', () => {
       },
     };
 
-    vi.stubGlobal(
-      'fetch',
-      vi.fn().mockResolvedValue({
-        ok: false,
-        status: 401,
-        json: async () => ({}),
-      } as Response),
-    );
+    vi.stubGlobal('fetch', vi.fn());
 
     render(EventDetailPage, { props: { data: buildData(event) } });
 

--- a/client/src/app.html
+++ b/client/src/app.html
@@ -9,7 +9,7 @@
       rel="stylesheet"
     />
   </head>
-  <body class="flex min-h-screen flex-col" data-sveltekit-preload-data="hover">
+  <body class="flex min-h-screen flex-col" data-sveltekit-preload-data="tap">
     <div style="display: contents">%sveltekit.body%</div>
   </body>
 </html>

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -95,18 +95,14 @@
 
   onDestroy(() => { if (countdownInterval) clearInterval(countdownInterval); });
 
-  async function removeStaleLocalStorageEntries(eventId: string) {
+  // Drops stored RSVP tokens whose RSVP no longer exists server-side. Uses the
+  // `rsvps` from the page load rather than a fresh fetch; the load refetches on
+  // every navigation right before this mount, so the data is current.
+  function removeStaleLocalStorageEntries(eventId: string, rsvps: Rsvp[]) {
     const users = getAllUsersForEvent(eventId);
     if (!users || users.length === 0) return;
 
-    const res = await fetch(`${API_HOST}/events/${event.id}`);
-    if (!res.ok) {
-      console.error('Failed to sync RSVPs');
-      return;
-    }
-    const fetchData = await res.json();
-    const rsvps = fetchData.rsvp;
-    const validIds = rsvps.map((r: { id: any; }) => r.id);
+    const validIds = rsvps.map((r) => r.id);
 
     // Remove stale localStorage entries
     const myEvents = JSON.parse(localStorage.getItem('my_events') || '{}');
@@ -126,10 +122,10 @@
     localStorage.setItem('my_events', JSON.stringify(myEvents));
   }
 
-  onMount(async () => {
+  onMount(() => {
     mounted = true;
 
-    await removeStaleLocalStorageEntries(event.id);
+    removeStaleLocalStorageEntries(event.id, attendees);
 
     user = getUser(event.id)
     users = getAllUsersForEvent(event.id)
@@ -142,13 +138,20 @@
         guests = found.guests ? String(found.guests) : "0";
       }
     }
-    adminFetch(`${API_HOST}/admin/login`, { method: 'POST' }).then(res => {
-      isAdmin = res.ok;
-    }).catch(() => {
+
+    const hasStoredCredentials = !!localStorage.getItem('credentials');
+    if (hasStoredCredentials) {
+      adminFetch(`${API_HOST}/admin/login`, { method: 'POST' }).then(res => {
+        isAdmin = res.ok;
+      }).catch(() => {
+        isAdmin = false;
+      }).finally(() => {
+        startCountdown();
+      });
+    } else {
       isAdmin = false;
-    }).finally(() => {
       startCountdown();
-    });
+    }
 
     // import the web component only in the browser
     import('add-to-calendar-button');


### PR DESCRIPTION
Reduce server calls per event details page load from 3 for all users to 1 for non-admins and 2 for admins. Also stop prefetching event details on hover in the event listing pages (My RSVPs, All Events).

- Drop the redundant GET /events/:id in removeStaleLocalStorageEntries; reuse the attendees already loaded by +page.ts
- Only fire the /admin/login probe when admin credentials are stored, so non-admin visitors skip it on every event page view
- Set SvelteKit preload to "tap" so navigation stays instant without hover-triggered speculative loads from event list pages