### PR TITLE
Add server integration tests with Supertest

### DIFF
--- a/server/README.md
+++ b/server/README.md
@@ -45,7 +45,7 @@ SQLITE_DB_PATH=./data/event_rsvp.db # optional, default is ./data/event_rsvp.db
 
 ## Testing
 
-Run the unit test suite:
+Run the full test suite (unit + integration):
 ```sh
 yarn test
 ```
@@ -55,7 +55,9 @@ Run in watch mode during development:
 yarn test:watch
 ```
 
-Tests live in `src/__tests__/unit/` and cover middleware, services, and validators.
+Tests run against an in-memory SQLite database and live in `src/__tests__/`:
+- `unit/` — middleware, services, and validators
+- `integration/` — HTTP-level tests of the API (routes + middleware) driven by Supertest
 
 ## Notes
 - All admin routes require a Basic Authorization header: `Basic USER:PASS` (credentials from `.env`).

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,9 @@
     "@types/cors": "^2",
     "@types/express": "^5.0.3",
     "@types/node": "^24.2.1",
+    "@types/supertest": "^7.2.0",
     "@vitest/coverage-v8": "^4.1.6",
+    "supertest": "^7.2.2",
     "ts-node": "^10.9.2",
     "typescript": "^5.9.2",
     "vitest": "^4.1.6"

--- a/server/src/__tests__/integration/adversarial.test.ts
+++ b/server/src/__tests__/integration/adversarial.test.ts
@@ -1,0 +1,136 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import server from './testServer';
+import db from '../../db';
+
+const AUTH = 'Basic testadmin:testpass';
+
+const BASE_EVENT = {
+  name: 'Test Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Venue',
+};
+
+let eventId: string;
+
+beforeEach(async () => {
+  db.prepare('DELETE FROM poll_votes').run();
+  db.prepare('DELETE FROM poll_options').run();
+  db.prepare('DELETE FROM polls').run();
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+
+  const res = await request(server)
+    .post('/admin/create-event')
+    .set('Authorization', AUTH)
+    .send(BASE_EVENT);
+  eventId = res.body.event.id;
+});
+
+describe('SQL injection safety', () => {
+  it('stores SQL injection payload in event name verbatim without dropping tables', async () => {
+    const payload = "'); DROP TABLE events; --";
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, name: payload })
+      .expect(201);
+    expect(res.body.event.name).toBe(payload);
+
+    const events = await request(server).get('/admin/events').set('Authorization', AUTH);
+    expect(events.body.events.length).toBeGreaterThanOrEqual(1);
+  });
+
+  it('stores single quotes in RSVP name without corruption', async () => {
+    const name = "O'Brien";
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name, status: 'going' })
+      .expect(201);
+    expect(res.body.rsvp.name).toBe(name);
+  });
+
+  it('stores a poll option URL with query parameters without corruption', async () => {
+    const url = 'https://example.com/venue?city=Berlin&cap=50&name=O%27Reilly';
+    const res = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: [{ name: 'Venue', url }] })
+      .expect(201);
+    expect(res.body.poll.options[0].url).toBe(url);
+  });
+});
+
+describe('IDOR — token/identity isolation', () => {
+  it("User A's rsvpId + User B's token cannot vote in a poll", async () => {
+    const rsvpA = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const rsvpB = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Bob', status: 'going' });
+
+    const pollRes = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Q', options: [{ name: 'A', url: 'https://a.example.com' }] });
+    const poll = pollRes.body.poll;
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({
+        rsvpId: rsvpA.body.rsvp.id,
+        token: rsvpB.body.rsvp.token,
+        optionIds: [poll.options[0].id],
+      })
+      .expect(403);
+  });
+
+  it("BUG: User A's event-1 rsvpId + token CAN vote in event 2's poll (cross-event)", async () => {
+    // BUG: a valid RSVP from event 1 can vote in event 2's poll because castVotes
+    // never verifies the RSVP belongs to the poll's event. This should be a 403.
+    const event2Res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_EVENT);
+    const event2Id = event2Res.body.event.id;
+
+    const rsvpEvent1 = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+
+    const pollRes = await request(server)
+      .post(`/admin/events/${event2Id}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Q', options: [{ name: 'A', url: 'https://a.example.com' }] });
+    const poll = pollRes.body.poll;
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({
+        rsvpId: rsvpEvent1.body.rsvp.id,
+        token: rsvpEvent1.body.rsvp.token,
+        optionIds: [poll.options[0].id],
+      })
+      .expect(200);
+  });
+});
+
+describe('Resource exhaustion boundaries', () => {
+  it('a body over the Express limit returns 500, not 413 (BUG: payload error not handled)', async () => {
+    // express.json() rejects bodies over its default ~100kb limit by throwing a
+    // PayloadTooLargeError (status 413). BUG: the errorHandler ignores err.status
+    // and always responds 500, so the client gets an opaque 500 instead of 413.
+    // The handler should map entity.too.large to 413 (and ideally set an explicit
+    // body limit).
+    const bigString = 'x'.repeat(1_100_000);
+    await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .set('Content-Type', 'application/json')
+      .send(`{"name":"${bigString}","date":"2025-12-25","startTime":"18:00","endTime":"22:00","location":"Venue"}`)
+      .expect(500);
+  });
+});

--- a/server/src/__tests__/integration/auth.test.ts
+++ b/server/src/__tests__/integration/auth.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest';
+import request from 'supertest';
+import server from './testServer';
+
+const VALID = 'Basic testadmin:testpass';
+const WRONG = 'Basic testadmin:wrong';
+
+describe('POST /admin/login', () => {
+  it('returns 200 for valid credentials', async () => {
+    await request(server).post('/admin/login').set('Authorization', VALID).expect(200);
+  });
+
+  it('returns 401 for wrong credentials', async () => {
+    await request(server).post('/admin/login').set('Authorization', WRONG).expect(401);
+  });
+
+  it('returns 401 when Authorization header is absent', async () => {
+    await request(server).post('/admin/login').expect(401);
+  });
+});
+
+describe('Admin route auth guard', () => {
+  it('rejects GET /admin/events without credentials', async () => {
+    await request(server).get('/admin/events').expect(401);
+  });
+
+  it('rejects POST /admin/create-event without credentials', async () => {
+    await request(server).post('/admin/create-event').send({}).expect(401);
+  });
+
+  it.each([
+    ['PATCH', '/admin/events/placeholder-id'],
+    ['DELETE', '/admin/events/placeholder-id'],
+    ['DELETE', '/admin/events/rsvp/placeholder-id'],
+    ['POST', '/admin/events/placeholder-id/poll'],
+    ['PATCH', '/admin/polls/placeholder-id/close'],
+    ['PATCH', '/admin/polls/placeholder-id/reopen'],
+    ['PATCH', '/admin/polls/placeholder-id'],
+    ['DELETE', '/admin/polls/placeholder-id'],
+  ])('%s %s returns 401 without credentials', async (method, path) => {
+    await (request(server) as any)[method.toLowerCase()](path).send({}).expect(401);
+  });
+});

--- a/server/src/__tests__/integration/events.test.ts
+++ b/server/src/__tests__/integration/events.test.ts
@@ -1,0 +1,269 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import server from './testServer';
+import db from '../../db';
+
+const AUTH = 'Basic testadmin:testpass';
+
+const BASE_BODY = {
+  name: 'Test Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Test Venue',
+};
+
+beforeEach(() => {
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+});
+
+describe('POST /admin/create-event', () => {
+  it('creates an event and returns 201', async () => {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY)
+      .expect(201);
+    expect(res.body.event.name).toBe('Test Event');
+    expect(res.body.event.id).toBeTruthy();
+  });
+
+  it('stores optional maxAttendees', async () => {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, maxAttendees: 50 })
+      .expect(201);
+    expect(res.body.event.max_attendees).toBe(50);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ name: 'Missing Date' })
+      .expect(400);
+    expect(res.body.error).toBeTruthy();
+  });
+
+  it('accepts a whitespace-only name (BUG: no trim validation)', async () => {
+    // BUG: the controller only checks `!name`, so a whitespace-only name passes
+    // and is stored verbatim. It should reject names that are empty after trim.
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, name: '   ' })
+      .expect(201);
+    expect(res.body.event.name).toBe('   ');
+  });
+
+  it('returns 400 when endTime is not after startTime', async () => {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, startTime: '20:00', endTime: '18:00' })
+      .expect(400);
+    expect(res.body.error).toMatch(/endTime/);
+  });
+
+  it('returns 400 when endTime equals startTime', async () => {
+    await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, startTime: '18:00', endTime: '18:00' })
+      .expect(400);
+  });
+
+  it('allows creating an event with a date in the past', async () => {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, date: '2000-01-01' })
+      .expect(201);
+    expect(res.body.event.date).toBe('2000-01-01');
+  });
+
+  it('accepts maxAttendees: 0 (treated as unlimited by the client)', async () => {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, maxAttendees: 0 })
+      .expect(201);
+    expect(res.body.event.max_attendees).toBe(0);
+  });
+
+  it('returns 401 without credentials', async () => {
+    await request(server).post('/admin/create-event').send(BASE_BODY).expect(401);
+  });
+});
+
+describe('GET /admin/events', () => {
+  it('returns the events list', async () => {
+    await request(server).post('/admin/create-event').set('Authorization', AUTH).send(BASE_BODY);
+    const res = await request(server).get('/admin/events').set('Authorization', AUTH).expect(200);
+    expect(res.body.events).toHaveLength(1);
+    expect(res.body.events[0].name).toBe('Test Event');
+  });
+
+  it('returns an empty array when no events exist', async () => {
+    const res = await request(server).get('/admin/events').set('Authorization', AUTH).expect(200);
+    expect(res.body.events).toEqual([]);
+  });
+});
+
+describe('GET /events/:id', () => {
+  it('returns the event with rsvp and poll fields', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+
+    const res = await request(server).get(`/events/${id}`).expect(200);
+    expect(res.body.event.id).toBe(id);
+    expect(res.body.rsvp).toEqual([]);
+    expect(res.body.poll).toBeNull();
+    expect(res.body.serverTime).toBeTypeOf('number');
+  });
+
+  it('returns 404 for a non-existent event', async () => {
+    await request(server).get('/events/no-such-id').expect(404);
+  });
+});
+
+describe('GET /events/:id — serverTime', () => {
+  it('serverTime is a number close to Date.now()', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+    const before = Date.now();
+    const res = await request(server).get(`/events/${id}`).expect(200);
+    const after = Date.now();
+    expect(res.body.serverTime).toBeGreaterThanOrEqual(before);
+    expect(res.body.serverTime).toBeLessThanOrEqual(after + 50);
+  });
+});
+
+describe('DELETE /admin/events/:id — cascade', () => {
+  it('cascades and removes associated RSVPs on event delete', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+
+    await request(server).post(`/events/${id}/rsvp`).send({ name: 'Alice', status: 'going' });
+    await request(server).delete(`/admin/events/${id}`).set('Authorization', AUTH).expect(200);
+
+    const rows = db.prepare('SELECT * FROM rsvp WHERE event_id = ?').all(id);
+    expect(rows).toHaveLength(0);
+  });
+
+  it('cascades and removes associated poll and votes on event delete', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+
+    const rsvpRes = await request(server).post(`/events/${id}/rsvp`).send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId, token } = rsvpRes.body.rsvp;
+
+    const pollRes = await request(server)
+      .post(`/admin/events/${id}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Q', options: [{ name: 'A', url: 'https://a.example.com' }] });
+    const pollId = pollRes.body.poll.id;
+    const optId = pollRes.body.poll.options[0].id;
+
+    await request(server).post(`/polls/${pollId}/vote`).send({ rsvpId, token, optionIds: [optId] });
+
+    await request(server).delete(`/admin/events/${id}`).set('Authorization', AUTH).expect(200);
+
+    const polls = db.prepare('SELECT * FROM polls WHERE event_id = ?').all(id);
+    const votes = db.prepare('SELECT * FROM poll_votes WHERE poll_option_id = ?').all(optId);
+    expect(polls).toHaveLength(0);
+    expect(votes).toHaveLength(0);
+  });
+});
+
+describe('PATCH /admin/events/:id — capacity edge cases', () => {
+  it('shrinking maxAttendees below current going count is accepted by the server', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_BODY, maxAttendees: 5 });
+    const id = created.body.event.id;
+
+    for (let i = 0; i < 3; i++) {
+      await request(server).post(`/events/${id}/rsvp`).send({ name: `User${i}`, status: 'going' });
+    }
+
+    const res = await request(server)
+      .patch(`/admin/events/${id}`)
+      .set('Authorization', AUTH)
+      .send({ maxAttendees: 1 })
+      .expect(200);
+    expect(res.body.event.max_attendees).toBe(1);
+  });
+});
+
+describe('PATCH /admin/events/:id', () => {
+  it('updates an event and returns the updated data', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+
+    const res = await request(server)
+      .patch(`/admin/events/${id}`)
+      .set('Authorization', AUTH)
+      .send({ name: 'Updated Name' })
+      .expect(200);
+    expect(res.body.event.name).toBe('Updated Name');
+    expect(res.body.event.location).toBe('Test Venue');
+  });
+
+  it('returns 404 for a non-existent event', async () => {
+    await request(server)
+      .patch('/admin/events/ghost')
+      .set('Authorization', AUTH)
+      .send({ name: 'X' })
+      .expect(404);
+  });
+
+  it('returns 400 when endTime is not after startTime', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+
+    await request(server)
+      .patch(`/admin/events/${id}`)
+      .set('Authorization', AUTH)
+      .send({ startTime: '20:00', endTime: '10:00' })
+      .expect(400);
+  });
+});
+
+describe('DELETE /admin/events/:id', () => {
+  it('deletes an event and returns 200', async () => {
+    const created = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_BODY);
+    const id = created.body.event.id;
+
+    await request(server).delete(`/admin/events/${id}`).set('Authorization', AUTH).expect(200);
+    await request(server).get(`/events/${id}`).expect(404);
+  });
+
+  it('returns 404 for a non-existent event', async () => {
+    await request(server).delete('/admin/events/ghost').set('Authorization', AUTH).expect(404);
+  });
+});

--- a/server/src/__tests__/integration/polls.test.ts
+++ b/server/src/__tests__/integration/polls.test.ts
@@ -1,0 +1,483 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import server from './testServer';
+import db from '../../db';
+
+const AUTH = 'Basic testadmin:testpass';
+
+const BASE_EVENT = {
+  name: 'Test Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Venue',
+};
+
+const TWO_OPTIONS = [
+  { name: 'Option A', url: 'https://a.example.com' },
+  { name: 'Option B', url: 'https://b.example.com' },
+];
+
+let eventId: string;
+let rsvpId: string;
+let rsvpToken: string;
+
+beforeEach(async () => {
+  db.prepare('DELETE FROM poll_votes').run();
+  db.prepare('DELETE FROM poll_options').run();
+  db.prepare('DELETE FROM polls').run();
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+
+  const eventRes = await request(server)
+    .post('/admin/create-event')
+    .set('Authorization', AUTH)
+    .send(BASE_EVENT);
+  eventId = eventRes.body.event.id;
+
+  const rsvpRes = await request(server)
+    .post(`/events/${eventId}/rsvp`)
+    .send({ name: 'Voter', status: 'going' });
+  rsvpId = rsvpRes.body.rsvp.id;
+  rsvpToken = rsvpRes.body.rsvp.token;
+});
+
+describe('POST /admin/events/:id/poll', () => {
+  it('creates a poll with status open', async () => {
+    const res = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS })
+      .expect(201);
+    expect(res.body.poll.status).toBe('open');
+    expect(res.body.poll.options).toHaveLength(2);
+  });
+
+  it('returns 400 when title is missing', async () => {
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ options: TWO_OPTIONS })
+      .expect(400);
+  });
+
+  it('returns 400 when options array is empty', async () => {
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: [] })
+      .expect(400);
+  });
+
+  it('returns 400 when an option is missing url', async () => {
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: [{ name: 'A' }] })
+      .expect(400);
+  });
+
+  it('returns 400 when options is null (non-array)', async () => {
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: null })
+      .expect(400);
+  });
+
+  it('accepts a whitespace-only option name (BUG: no trim validation)', async () => {
+    // BUG: the controller only checks `!opt.name`, so a whitespace-only option
+    // name passes validation and is stored. It should reject empty-after-trim.
+    const res = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: [{ name: '   ', url: 'https://example.com' }] })
+      .expect(201);
+    expect(res.body.poll.options[0].name).toBe('   ');
+  });
+
+  it('returns 401 without credentials', async () => {
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .send({ title: 'Where?', options: TWO_OPTIONS })
+      .expect(401);
+  });
+
+  it('allows creating a second poll for the same event (BUG: duplicate polls)', async () => {
+    // BUG: there is no UNIQUE(event_id) constraint and createPoll does not check
+    // for an existing poll, so a second POST succeeds and creates a duplicate.
+    // getPollByEventId then returns only one of them (the first), leaving the
+    // second as an orphaned, unreachable row. This should be a 409 (or update).
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'First', options: TWO_OPTIONS })
+      .expect(201);
+    await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Second', options: TWO_OPTIONS })
+      .expect(201);
+
+    const polls = db.prepare('SELECT * FROM polls WHERE event_id = ?').all(eventId);
+    expect(polls).toHaveLength(2);
+    // Only the first poll is reachable through the API.
+    const eventRes = await request(server).get(`/events/${eventId}`);
+    expect(eventRes.body.poll.title).toBe('First');
+  });
+});
+
+describe('PATCH /admin/polls/:id/close and /reopen', () => {
+  it('closes an open poll', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    const res = await request(server)
+      .patch(`/admin/polls/${pollId}/close`)
+      .set('Authorization', AUTH)
+      .expect(200);
+    expect(res.body.poll.status).toBe('closed');
+  });
+
+  it('reopens a closed poll', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    await request(server).patch(`/admin/polls/${pollId}/close`).set('Authorization', AUTH);
+    const res = await request(server)
+      .patch(`/admin/polls/${pollId}/reopen`)
+      .set('Authorization', AUTH)
+      .expect(200);
+    expect(res.body.poll.status).toBe('open');
+  });
+
+  it('returns 404 when closing an already-closed poll', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    await request(server).patch(`/admin/polls/${pollId}/close`).set('Authorization', AUTH);
+    await request(server)
+      .patch(`/admin/polls/${pollId}/close`)
+      .set('Authorization', AUTH)
+      .expect(404);
+  });
+
+  it('returns 404 when reopening an already-open poll', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    await request(server)
+      .patch(`/admin/polls/${pollId}/reopen`)
+      .set('Authorization', AUTH)
+      .expect(404);
+  });
+});
+
+describe('PATCH /admin/polls/:id', () => {
+  it('updates the poll title and options', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Old', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+
+    const updatedOptions = poll.options.map((o: any) => ({ id: o.id, name: o.name, url: o.url }));
+    const res = await request(server)
+      .patch(`/admin/polls/${poll.id}`)
+      .set('Authorization', AUTH)
+      .send({ title: 'New', options: updatedOptions })
+      .expect(200);
+    expect(res.body.poll.title).toBe('New');
+  });
+
+  it('returns 404 for a non-existent poll', async () => {
+    await request(server)
+      .patch('/admin/polls/ghost')
+      .set('Authorization', AUTH)
+      .send({ title: 'T', options: [{ name: 'x', url: 'x' }] })
+      .expect(404);
+  });
+
+  it('returns 400 when title is missing', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+
+    await request(server)
+      .patch(`/admin/polls/${poll.id}`)
+      .set('Authorization', AUTH)
+      .send({ options: poll.options.map((o: any) => ({ id: o.id, name: o.name, url: o.url })) })
+      .expect(400);
+  });
+
+  it('returns 400 when an option is missing url', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+
+    await request(server)
+      .patch(`/admin/polls/${poll.id}`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: [{ name: 'No URL' }] })
+      .expect(400);
+  });
+});
+
+describe('DELETE /admin/polls/:id', () => {
+  it('deletes a poll and returns 200', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    await request(server).delete(`/admin/polls/${pollId}`).set('Authorization', AUTH).expect(200);
+
+    const eventRes = await request(server).get(`/events/${eventId}`);
+    expect(eventRes.body.poll).toBeNull();
+  });
+
+  it('returns 404 for a non-existent poll', async () => {
+    await request(server).delete('/admin/polls/ghost').set('Authorization', AUTH).expect(404);
+  });
+});
+
+describe('POST /polls/:id/vote', () => {
+  it('records votes and returns the updated poll', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+    const optionId = poll.options[0].id;
+
+    const res = await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [optionId] })
+      .expect(200);
+    const votedOption = res.body.poll.options.find((o: any) => o.id === optionId);
+    expect(votedOption.votes).toHaveLength(1);
+    expect(votedOption.votes[0].voter_name).toBe('Voter');
+  });
+
+  it('returns 403 when the token is wrong', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    await request(server)
+      .post(`/polls/${pollId}/vote`)
+      .send({ rsvpId, token: 'wrongtoken', optionIds: [created.body.poll.options[0].id] })
+      .expect(403);
+  });
+
+  it('returns 400 when required fields are missing', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const pollId = created.body.poll.id;
+
+    await request(server).post(`/polls/${pollId}/vote`).send({ rsvpId }).expect(400);
+  });
+
+  it('returns 403 when the poll is closed', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+
+    await request(server).patch(`/admin/polls/${poll.id}/close`).set('Authorization', AUTH);
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [poll.options[0].id] })
+      .expect(403);
+  });
+
+  it('accepts empty optionIds and clears all previous votes', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [poll.options[0].id] });
+
+    const res = await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [] })
+      .expect(200);
+
+    const option = res.body.poll.options.find((o: any) => o.id === poll.options[0].id);
+    expect(option.votes).toHaveLength(0);
+  });
+
+  it('returns 403 for a non-existent poll', async () => {
+    await request(server)
+      .post('/polls/no-such-poll-id/vote')
+      .send({ rsvpId, token: rsvpToken, optionIds: [] })
+      .expect(403);
+  });
+
+  it('duplicate optionIds in payload cause a 500 (BUG: not deduplicated)', async () => {
+    // BUG: castVotes inserts one poll_votes row per submitted optionId without
+    // deduplicating, so a repeated optionId violates the (poll_option_id, rsvp_id)
+    // primary key, the transaction throws, and it surfaces as an unhandled 500.
+    // The service should dedupe optionIds (or INSERT OR IGNORE) before inserting.
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+    const optId = poll.options[0].id;
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [optId, optId] })
+      .expect(500);
+  });
+
+  it('allows an RSVP from a different event to vote (BUG: cross-event voting)', async () => {
+    // BUG: castVotes only checks that the rsvpId+token pair is valid and that the
+    // option belongs to the poll — it never checks the RSVP belongs to the poll's
+    // event. So a token from event B can vote in event A's poll. It should reject
+    // when rsvp.event_id !== poll.event_id (returns null -> 403).
+    const otherEventRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_EVENT);
+    const otherEventId = otherEventRes.body.event.id;
+
+    const otherRsvpRes = await request(server)
+      .post(`/events/${otherEventId}/rsvp`)
+      .send({ name: 'Eve', status: 'going' });
+    const otherRsvpId = otherRsvpRes.body.rsvp.id;
+    const otherToken = otherRsvpRes.body.rsvp.token;
+
+    const pollRes = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = pollRes.body.poll;
+
+    const res = await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId: otherRsvpId, token: otherToken, optionIds: [poll.options[0].id] })
+      .expect(200);
+    const voted = res.body.poll.options.find((o: any) => o.id === poll.options[0].id);
+    expect(voted.votes).toHaveLength(1);
+  });
+
+  it('returns 403 when voting after the RSVP has been deleted', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+
+    await request(server)
+      .delete(`/admin/events/rsvp/${rsvpId}`)
+      .set('Authorization', AUTH);
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [poll.options[0].id] })
+      .expect(403);
+  });
+
+  it('two simultaneous votes from the same rsvpId do not double-count', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+    const optId = poll.options[0].id;
+
+    const [r1, r2] = await Promise.all([
+      request(server).post(`/polls/${poll.id}/vote`).send({ rsvpId, token: rsvpToken, optionIds: [optId] }),
+      request(server).post(`/polls/${poll.id}/vote`).send({ rsvpId, token: rsvpToken, optionIds: [optId] }),
+    ]);
+
+    expect(r1.status).toBe(200);
+    expect(r2.status).toBe(200);
+
+    const eventRes = await request(server).get(`/events/${eventId}`);
+    const option = eventRes.body.poll.options.find((o: any) => o.id === optId);
+    expect(option.votes).toHaveLength(1);
+  });
+});
+
+describe('PATCH /admin/polls/:id — option cascade', () => {
+  it('removing an option from the update payload deletes its votes', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+    const removedOptId = poll.options[0].id;
+    const keptOptId = poll.options[1].id;
+
+    await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [removedOptId] });
+
+    const keptOption = poll.options.find((o: any) => o.id === keptOptId);
+    await request(server)
+      .patch(`/admin/polls/${poll.id}`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Updated', options: [{ id: keptOptId, name: keptOption.name, url: keptOption.url }] })
+      .expect(200);
+
+    const votes = db.prepare('SELECT * FROM poll_votes WHERE poll_option_id = ?').all(removedOptId);
+    expect(votes).toHaveLength(0);
+  });
+
+  it('adding a new option lets users vote for it', async () => {
+    const created = await request(server)
+      .post(`/admin/events/${eventId}/poll`)
+      .set('Authorization', AUTH)
+      .send({ title: 'Where?', options: TWO_OPTIONS });
+    const poll = created.body.poll;
+    const existingOptions = poll.options.map((o: any) => ({ id: o.id, name: o.name, url: o.url }));
+
+    const updated = await request(server)
+      .patch(`/admin/polls/${poll.id}`)
+      .set('Authorization', AUTH)
+      .send({
+        title: 'Where?',
+        options: [...existingOptions, { name: 'Option C', url: 'https://c.example.com' }],
+      })
+      .expect(200);
+    expect(updated.body.poll.options).toHaveLength(3);
+
+    const newOptId = updated.body.poll.options.find((o: any) => o.name === 'Option C').id;
+    const voteRes = await request(server)
+      .post(`/polls/${poll.id}/vote`)
+      .send({ rsvpId, token: rsvpToken, optionIds: [newOptId] })
+      .expect(200);
+    const newOpt = voteRes.body.poll.options.find((o: any) => o.id === newOptId);
+    expect(newOpt.votes).toHaveLength(1);
+  });
+});

--- a/server/src/__tests__/integration/rsvps.test.ts
+++ b/server/src/__tests__/integration/rsvps.test.ts
@@ -1,0 +1,329 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import request from 'supertest';
+import server from './testServer';
+import db from '../../db';
+
+const AUTH = 'Basic testadmin:testpass';
+
+const BASE_EVENT = {
+  name: 'Test Event',
+  date: '2025-12-25',
+  startTime: '18:00',
+  endTime: '22:00',
+  location: 'Venue',
+};
+
+let eventId: string;
+
+beforeEach(async () => {
+  db.prepare('DELETE FROM rsvp').run();
+  db.prepare('DELETE FROM events').run();
+  const res = await request(server)
+    .post('/admin/create-event')
+    .set('Authorization', AUTH)
+    .send(BASE_EVENT);
+  eventId = res.body.event.id;
+});
+
+describe('POST /events/:id/rsvp', () => {
+  it('creates an RSVP and returns 201', async () => {
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' })
+      .expect(201);
+    expect(res.body.rsvp.name).toBe('Alice');
+    expect(res.body.rsvp.token).toBeTruthy();
+  });
+
+  it('accepts guest count', async () => {
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going', guests: 2 })
+      .expect(201);
+    expect(res.body.rsvp.guests).toBe(2);
+  });
+
+  it('returns 400 when name is missing', async () => {
+    await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ status: 'going' })
+      .expect(400);
+  });
+
+  it('accepts a whitespace-only name (BUG: no trim validation)', async () => {
+    // BUG: the controller only checks `!name`, so a whitespace-only name passes
+    // and is stored verbatim. It should reject names that are empty after trim.
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: '   ', status: 'going' })
+      .expect(201);
+    expect(res.body.rsvp.name).toBe('   ');
+  });
+
+  it('accepts a negative guest count (BUG: no guest-count validation)', async () => {
+    // BUG: the server never validates `guests`, so a negative count is stored
+    // verbatim. It should reject non-integer or negative guest counts with a 400.
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going', guests: -1 })
+      .expect(201);
+    expect(res.body.rsvp.guests).toBe(-1);
+  });
+
+  it('returns 400 for an invalid status', async () => {
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'yes' })
+      .expect(400);
+    expect(res.body.error).toMatch(/status/i);
+  });
+
+  it('returns 404 for a non-existent event', async () => {
+    await request(server)
+      .post('/events/no-such-event/rsvp')
+      .send({ name: 'Alice', status: 'going' })
+      .expect(404);
+  });
+
+  it('blocks registration when registrationOpensAt is in the future', async () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const eventRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, registrationOpensAt: future });
+    const futureEventId = eventRes.body.event.id;
+
+    await request(server)
+      .post(`/events/${futureEventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' })
+      .expect(403);
+  });
+
+  it('accepts a name consisting entirely of emoji', async () => {
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: '🎉🎊🎈', status: 'going' })
+      .expect(201);
+    expect(res.body.rsvp.name).toBe('🎉🎊🎈');
+  });
+
+  it('stores an HTML/script payload in the name verbatim (no server-side sanitization)', async () => {
+    const xssName = '<script>alert(1)</script>';
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: xssName, status: 'going' })
+      .expect(201);
+    expect(res.body.rsvp.name).toBe(xssName);
+  });
+
+  it('accepts guests > 0 with status: maybe (server stores raw value)', async () => {
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'maybe', guests: 3 })
+      .expect(201);
+    expect(res.body.rsvp.guests).toBe(3);
+    expect(res.body.rsvp.status).toBe('maybe');
+  });
+
+  it('accepts very large guest counts', async () => {
+    const res = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going', guests: 9999 })
+      .expect(201);
+    expect(res.body.rsvp.guests).toBe(9999);
+  });
+
+  it('allows RSVPing to an event with a past date', async () => {
+    const pastEventRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, date: '2000-01-01' });
+    const pastId = pastEventRes.body.event.id;
+    await request(server)
+      .post(`/events/${pastId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' })
+      .expect(201);
+  });
+
+  it('allows RSVPing exactly when registrationOpensAt is within the 1-second grace window', async () => {
+    const justOpened = new Date(Date.now() - 500).toISOString();
+    const eventRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, registrationOpensAt: justOpened });
+    const id = eventRes.body.event.id;
+    await request(server)
+      .post(`/events/${id}/rsvp`)
+      .send({ name: 'Alice', status: 'going' })
+      .expect(201);
+  });
+
+  it('two simultaneous RSVPs to a capacity=1 event both succeed (no server-side capacity gate)', async () => {
+    const capRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, maxAttendees: 1 });
+    const capId = capRes.body.event.id;
+
+    const [r1, r2] = await Promise.all([
+      request(server).post(`/events/${capId}/rsvp`).send({ name: 'Alice', status: 'going' }),
+      request(server).post(`/events/${capId}/rsvp`).send({ name: 'Bob', status: 'going' }),
+    ]);
+    expect(r1.status).toBe(201);
+    expect(r2.status).toBe(201);
+
+    const eventRes = await request(server).get(`/events/${capId}`);
+    expect(eventRes.body.rsvp).toHaveLength(2);
+  });
+
+  it('allows admin to RSVP even when registration is not yet open', async () => {
+    const future = new Date(Date.now() + 3_600_000).toISOString();
+    const eventRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send({ ...BASE_EVENT, registrationOpensAt: future });
+    const futureEventId = eventRes.body.event.id;
+
+    await request(server)
+      .post(`/events/${futureEventId}/rsvp`)
+      .set('Authorization', AUTH)
+      .send({ name: 'Admin', status: 'going' })
+      .expect(201);
+  });
+});
+
+describe('PATCH /events/:id/rsvp/:rsvpId', () => {
+  it('updates the RSVP when the correct token is provided', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId, token } = rsvpRes.body.rsvp;
+
+    const res = await request(server)
+      .patch(`/events/${eventId}/rsvp/${rsvpId}`)
+      .send({ token, name: 'Alice B', status: 'maybe', guests: 1 })
+      .expect(200);
+    expect(res.body.rsvp.name).toBe('Alice B');
+    expect(res.body.rsvp.status).toBe('maybe');
+    expect(res.body.rsvp.guests).toBe(1);
+  });
+
+  it('returns 404 when the token is wrong', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId } = rsvpRes.body.rsvp;
+
+    await request(server)
+      .patch(`/events/${eventId}/rsvp/${rsvpId}`)
+      .send({ token: 'wrongtoken', name: 'Alice', status: 'going', guests: 0 })
+      .expect(404);
+  });
+
+  it('returns 404 when the event id in the URL does not match the RSVP event', async () => {
+    const otherEventRes = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(BASE_EVENT);
+    const otherEventId = otherEventRes.body.event.id;
+
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId, token } = rsvpRes.body.rsvp;
+
+    await request(server)
+      .patch(`/events/${otherEventId}/rsvp/${rsvpId}`)
+      .send({ token, name: 'Alice', status: 'going', guests: 0 })
+      .expect(404);
+  });
+
+  it('returns 400 when token is missing from request body', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId } = rsvpRes.body.rsvp;
+
+    await request(server)
+      .patch(`/events/${eventId}/rsvp/${rsvpId}`)
+      .send({ name: 'Alice', status: 'going' })
+      .expect(400);
+  });
+
+  it('returns 400 for an invalid status', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId, token } = rsvpRes.body.rsvp;
+
+    await request(server)
+      .patch(`/events/${eventId}/rsvp/${rsvpId}`)
+      .send({ token, name: 'Alice', status: 'yes' })
+      .expect(400);
+  });
+
+  it('returns 404 when using a stale/mismatched token', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const { id: rsvpId } = rsvpRes.body.rsvp;
+
+    await request(server)
+      .patch(`/events/${eventId}/rsvp/${rsvpId}`)
+      .send({ token: 'stale-token-that-never-matched', name: 'Alice', status: 'going', guests: 0 })
+      .expect(404);
+  });
+});
+
+describe('DELETE /admin/events/rsvp/:id', () => {
+  it('deletes an RSVP and returns 200', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const rsvpId = rsvpRes.body.rsvp.id;
+
+    await request(server)
+      .delete(`/admin/events/rsvp/${rsvpId}`)
+      .set('Authorization', AUTH)
+      .expect(200);
+
+    const eventRes = await request(server).get(`/events/${eventId}`);
+    expect(eventRes.body.rsvp).toHaveLength(0);
+  });
+
+  it('returns 404 for a non-existent RSVP', async () => {
+    await request(server)
+      .delete('/admin/events/rsvp/ghost')
+      .set('Authorization', AUTH)
+      .expect(404);
+  });
+});
+
+describe('POST /rsvps/my', () => {
+  it('returns events matching the supplied rsvpId/eventId pairs', async () => {
+    const rsvpRes = await request(server)
+      .post(`/events/${eventId}/rsvp`)
+      .send({ name: 'Alice', status: 'going' });
+    const rsvpId = rsvpRes.body.rsvp.id;
+
+    const res = await request(server)
+      .post('/rsvps/my')
+      .send({ myRsvps: [{ rsvpId, eventId }] })
+      .expect(200);
+    expect(res.body.rsvps).toHaveLength(1);
+    expect(res.body.rsvps[0].yourStatus).toBe('going');
+    expect(res.body.rsvps[0].attendeeName).toBe('Alice');
+  });
+
+  it('returns 400 when myRsvps is not an array', async () => {
+    await request(server).post('/rsvps/my').send({ myRsvps: 'bad' }).expect(400);
+  });
+
+  it('returns empty array when no pairs match', async () => {
+    const res = await request(server)
+      .post('/rsvps/my')
+      .send({ myRsvps: [{ rsvpId: 'ghost', eventId: 'ghost' }] })
+      .expect(200);
+    expect(res.body.rsvps).toEqual([]);
+  });
+});

--- a/server/src/__tests__/integration/testServer.ts
+++ b/server/src/__tests__/integration/testServer.ts
@@ -1,0 +1,11 @@
+import app from '../../app';
+import type { Server } from 'node:http';
+
+// One listening server per test file (Vitest isolates module state per file),
+// reused across every request in that file. This avoids Supertest spinning up —
+// and tearing down — an ephemeral server for each individual `request(app)`
+// call, which under Vitest's parallel workers intermittently stalls or drops
+// connections and makes the HTTP tests flaky. Pass this to `request(server)`.
+const server: Server = app.listen(0);
+
+export default server;

--- a/server/src/app.ts
+++ b/server/src/app.ts
@@ -1,0 +1,23 @@
+import express, { Request, Response } from 'express';
+import cors from 'cors';
+import router from './routes';
+import { errorHandler } from './utils/errorHandler';
+import { requestInfoLogger } from './middlewares/logger';
+
+const app = express();
+
+app.use(cors());
+app.use(express.json());
+// The per-request logger is pure noise under test (one line per request, ×100s).
+if (process.env.NODE_ENV !== 'test') {
+  app.use(requestInfoLogger);
+}
+app.use(router);
+
+app.get('/ping', (_req: Request, res: Response) => {
+  res.send('pong');
+});
+
+app.use(errorHandler);
+
+export default app;

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,34 +1,14 @@
-import config from './config'
-import express, { Request, Response } from "express";
-import router from "./routes";
-import { errorHandler } from './utils/errorHandler';
-import seed from './db/seed'; // ensure the database is seeded before starting the server
-import cors from 'cors';
-import { requestInfoLogger } from './middlewares/logger';
+import app from './app';
+import seed from './db/seed';
+import config from './config';
 
-// Ensure the database is seeded before starting the server
-seed()
+seed();
 
-const app = express();
-const port = config.PORT;
-
-app.use(cors());
-app.use(express.json());
-app.use(requestInfoLogger);
-app.use(router);
-
-app.get("/ping", (req: Request, res: Response) => {
-  res.send("pong");
+const server = app.listen(config.PORT, () => {
+  console.log(`Server is running on port ${config.PORT}`);
 });
 
-// Error handling middleware should be registered after all routes
-app.use(errorHandler);
-
-const server = app.listen(port, () => {
-  console.log(`Server is running on port ${port}`);
-});
-
-process.on("SIGTERM", () => {
-  console.log("SIGTERM received, shutting down...");
+process.on('SIGTERM', () => {
+  console.log('SIGTERM received, shutting down...');
   server.close(() => process.exit(0));
 });

--- a/server/vitest.config.ts
+++ b/server/vitest.config.ts
@@ -5,7 +5,8 @@ export default defineConfig({
     environment: 'node',
     setupFiles: ['./src/__tests__/setup.ts'],
     env: {
-      // NODE_ENV=test makes config/index.ts skip dotenv so tests never read .env
+      // NODE_ENV=test makes config/index.ts skip dotenv and app.ts skip the
+      // request logger, so the suite uses only the injected env.
       NODE_ENV: 'test',
       SQLITE_DB_PATH: ':memory:',
       ADMIN_USER: 'testadmin',

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -153,6 +153,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@noble/hashes@npm:^1.1.5":
+  version: 1.8.0
+  resolution: "@noble/hashes@npm:1.8.0"
+  checksum: 10c0/06a0b52c81a6fa7f04d67762e08b2c476a00285858150caeaaff4037356dd5e119f45b2a530f638b77a5eeca013168ec1b655db41bae3236cb2e9d511484fc77
+  languageName: node
+  linkType: hard
+
 "@npmcli/agent@npm:^3.0.0":
   version: 3.0.0
   resolution: "@npmcli/agent@npm:3.0.0"
@@ -179,6 +186,15 @@ __metadata:
   version: 0.130.0
   resolution: "@oxc-project/types@npm:0.130.0"
   checksum: 10c0/7ec8c03407b0bcb235b930c62859e6efcb3fe5cbaa5db98770d760df5c3e6b3e28a0ad22c2e35d1addede8065b40000c3822c5235dde2959af226639eb870000
+  languageName: node
+  linkType: hard
+
+"@paralleldrive/cuid2@npm:^2.2.2":
+  version: 2.3.1
+  resolution: "@paralleldrive/cuid2@npm:2.3.1"
+  dependencies:
+    "@noble/hashes": "npm:^1.1.5"
+  checksum: 10c0/6576b73de49d826b0f33cbab88424dec1f6fa454a9e59a7b621f78c2cfdd2e59d7f48175826d698940a717f45eeb5e87a508583a7316e608f6a05a861a40c129
   languageName: node
   linkType: hard
 
@@ -387,6 +403,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/cookiejar@npm:^2.1.5":
+  version: 2.1.5
+  resolution: "@types/cookiejar@npm:2.1.5"
+  checksum: 10c0/af38c3d84aebb3ccc6e46fb6afeeaac80fb26e63a487dd4db5a8b87e6ad3d4b845ba1116b2ae90d6f886290a36200fa433d8b1f6fe19c47da6b81872ce9a2764
+  languageName: node
+  linkType: hard
+
 "@types/cors@npm:^2":
   version: 2.8.19
   resolution: "@types/cors@npm:2.8.19"
@@ -449,6 +472,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"@types/methods@npm:^1.1.4":
+  version: 1.1.4
+  resolution: "@types/methods@npm:1.1.4"
+  checksum: 10c0/a78534d79c300718298bfff92facd07bf38429c66191f640c1db4c9cff1e36f819304298a96f7536b6512bfc398e5c3e6b831405e138cd774b88ad7be78d682a
+  languageName: node
+  linkType: hard
+
 "@types/mime@npm:^1":
   version: 1.3.5
   resolution: "@types/mime@npm:1.3.5"
@@ -497,6 +527,28 @@ __metadata:
     "@types/node": "npm:*"
     "@types/send": "npm:*"
   checksum: 10c0/8ad86a25b87da5276cb1008c43c74667ff7583904d46d5fcaf0355887869d859d453d7dc4f890788ae04705c23720e9b6b6f3215e2d1d2a4278bbd090a9268dd
+  languageName: node
+  linkType: hard
+
+"@types/superagent@npm:^8.1.0":
+  version: 8.1.10
+  resolution: "@types/superagent@npm:8.1.10"
+  dependencies:
+    "@types/cookiejar": "npm:^2.1.5"
+    "@types/methods": "npm:^1.1.4"
+    "@types/node": "npm:*"
+    form-data: "npm:^4.0.0"
+  checksum: 10c0/cd911f7e926aae3f23caeebac055c46c5a63576561548356e0ca809147b372a27359112e02a569d527fd677cd90ee6d018b5cdf509a0a5ac70f74289bd29c9bc
+  languageName: node
+  linkType: hard
+
+"@types/supertest@npm:^7.2.0":
+  version: 7.2.0
+  resolution: "@types/supertest@npm:7.2.0"
+  dependencies:
+    "@types/methods": "npm:^1.1.4"
+    "@types/superagent": "npm:^8.1.0"
+  checksum: 10c0/78c33e968acd45207acdd965ccbd5eb7a279813ff68fab1acc438937ed017698102cc077cef8aa60ec6caefff2fa61171e902eab40607fd7ce82ead3a82b766e
   languageName: node
   linkType: hard
 
@@ -685,6 +737,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"asap@npm:^2.0.0":
+  version: 2.0.6
+  resolution: "asap@npm:2.0.6"
+  checksum: 10c0/c6d5e39fe1f15e4b87677460bd66b66050cd14c772269cee6688824c1410a08ab20254bb6784f9afb75af9144a9f9a7692d49547f4d19d715aeb7c0318f3136d
+  languageName: node
+  linkType: hard
+
 "assertion-error@npm:^2.0.1":
   version: 2.0.1
   resolution: "assertion-error@npm:2.0.1"
@@ -700,6 +759,27 @@ __metadata:
     estree-walker: "npm:^3.0.3"
     js-tokens: "npm:^10.0.0"
   checksum: 10c0/35e57b754ba63287358094d4f7ae8de2de27286fb4e76a1fbf28b2e67e3b670b59c3f511882473d0fd2cdbaa260062e3cd4f216b724c70032e2b09e5cebbd618
+  languageName: node
+  linkType: hard
+
+"async-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-function@npm:1.0.0"
+  checksum: 10c0/669a32c2cb7e45091330c680e92eaeb791bc1d4132d827591e499cd1f776ff5a873e77e5f92d0ce795a8d60f10761dec9ddfe7225a5de680f5d357f67b1aac73
+  languageName: node
+  linkType: hard
+
+"async-generator-function@npm:^1.0.0":
+  version: 1.0.0
+  resolution: "async-generator-function@npm:1.0.0"
+  checksum: 10c0/2c50ef856c543ad500d8d8777d347e3c1ba623b93e99c9263ecc5f965c1b12d2a140e2ab6e43c3d0b85366110696f28114649411cbcd10b452a92a2318394186
+  languageName: node
+  linkType: hard
+
+"asynckit@npm:^0.4.0":
+  version: 0.4.0
+  resolution: "asynckit@npm:0.4.0"
+  checksum: 10c0/d73e2ddf20c4eb9337e1b3df1a0f6159481050a5de457c55b14ea2e5cb6d90bb69e004c9af54737a5ee0917fcf2c9e25de67777bbe58261847846066ba75bc9d
   languageName: node
   linkType: hard
 
@@ -868,6 +948,22 @@ __metadata:
   languageName: node
   linkType: hard
 
+"combined-stream@npm:^1.0.8":
+  version: 1.0.8
+  resolution: "combined-stream@npm:1.0.8"
+  dependencies:
+    delayed-stream: "npm:~1.0.0"
+  checksum: 10c0/0dbb829577e1b1e839fa82b40c07ffaf7de8a09b935cadd355a73652ae70a88b4320db322f6634a4ad93424292fa80973ac6480986247f1734a1137debf271d5
+  languageName: node
+  linkType: hard
+
+"component-emitter@npm:^1.3.1":
+  version: 1.3.1
+  resolution: "component-emitter@npm:1.3.1"
+  checksum: 10c0/e4900b1b790b5e76b8d71b328da41482118c0f3523a516a41be598dc2785a07fd721098d9bf6e22d89b19f4fa4e1025160dc00317ea111633a3e4f75c2b86032
+  languageName: node
+  linkType: hard
+
 "content-disposition@npm:^1.0.0":
   version: 1.0.0
   resolution: "content-disposition@npm:1.0.0"
@@ -891,7 +987,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"cookie-signature@npm:^1.2.1":
+"cookie-signature@npm:^1.2.1, cookie-signature@npm:^1.2.2":
   version: 1.2.2
   resolution: "cookie-signature@npm:1.2.2"
   checksum: 10c0/54e05df1a293b3ce81589b27dddc445f462f6fa6812147c033350cd3561a42bc14481674e05ed14c7bd0ce1e8bb3dc0e40851bad75415733711294ddce0b7bc6
@@ -902,6 +998,13 @@ __metadata:
   version: 0.7.2
   resolution: "cookie@npm:0.7.2"
   checksum: 10c0/9596e8ccdbf1a3a88ae02cf5ee80c1c50959423e1022e4e60b91dd87c622af1da309253d8abdb258fb5e3eacb4f08e579dc58b4897b8087574eee0fd35dfa5d2
+  languageName: node
+  linkType: hard
+
+"cookiejar@npm:^2.1.4":
+  version: 2.1.4
+  resolution: "cookiejar@npm:2.1.4"
+  checksum: 10c0/2dae55611c6e1678f34d93984cbd4bda58f4fe3e5247cc4993f4a305cd19c913bbaf325086ed952e892108115073a747596453d3dc1c34947f47f731818b8ad1
   languageName: node
   linkType: hard
 
@@ -945,6 +1048,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"debug@npm:^4.3.7":
+  version: 4.4.3
+  resolution: "debug@npm:4.4.3"
+  dependencies:
+    ms: "npm:^2.1.3"
+  peerDependenciesMeta:
+    supports-color:
+      optional: true
+  checksum: 10c0/d79136ec6c83ecbefd0f6a5593da6a9c91ec4d7ddc4b54c883d6e71ec9accb5f67a1a5e96d00a328196b5b5c86d365e98d8a3a70856aaf16b4e7b1985e67f5a6
+  languageName: node
+  linkType: hard
+
 "decompress-response@npm:^6.0.0":
   version: 6.0.0
   resolution: "decompress-response@npm:6.0.0"
@@ -958,6 +1073,13 @@ __metadata:
   version: 0.6.0
   resolution: "deep-extend@npm:0.6.0"
   checksum: 10c0/1c6b0abcdb901e13a44c7d699116d3d4279fdb261983122a3783e7273844d5f2537dc2e1c454a23fcf645917f93fbf8d07101c1d03c015a87faa662755212566
+  languageName: node
+  linkType: hard
+
+"delayed-stream@npm:~1.0.0":
+  version: 1.0.0
+  resolution: "delayed-stream@npm:1.0.0"
+  checksum: 10c0/d758899da03392e6712f042bec80aa293bbe9e9ff1b2634baae6a360113e708b91326594c8a486d475c69d6259afb7efacdc3537bfcda1c6c648e390ce601b19
   languageName: node
   linkType: hard
 
@@ -979,6 +1101,16 @@ __metadata:
   version: 2.1.2
   resolution: "detect-libc@npm:2.1.2"
   checksum: 10c0/acc675c29a5649fa1fb6e255f993b8ee829e510b6b56b0910666949c80c364738833417d0edb5f90e4e46be17228b0f2b66a010513984e18b15deeeac49369c4
+  languageName: node
+  linkType: hard
+
+"dezalgo@npm:^1.0.4":
+  version: 1.0.4
+  resolution: "dezalgo@npm:1.0.4"
+  dependencies:
+    asap: "npm:^2.0.0"
+    wrappy: "npm:1"
+  checksum: 10c0/8a870ed42eade9a397e6141fe5c025148a59ed52f1f28b1db5de216b4d57f0af7a257070c3af7ce3d5508c1ce9dd5009028a76f4b2cc9370dc56551d2355fad8
   languageName: node
   linkType: hard
 
@@ -1104,6 +1236,18 @@ __metadata:
   languageName: node
   linkType: hard
 
+"es-set-tostringtag@npm:^2.1.0":
+  version: 2.1.0
+  resolution: "es-set-tostringtag@npm:2.1.0"
+  dependencies:
+    es-errors: "npm:^1.3.0"
+    get-intrinsic: "npm:^1.2.6"
+    has-tostringtag: "npm:^1.0.2"
+    hasown: "npm:^2.0.2"
+  checksum: 10c0/ef2ca9ce49afe3931cb32e35da4dcb6d86ab02592cfc2ce3e49ced199d9d0bb5085fc7e73e06312213765f5efa47cc1df553a6a5154584b21448e9fb8355b1af
+  languageName: node
+  linkType: hard
+
 "escape-html@npm:^1.0.3":
   version: 1.0.3
   resolution: "escape-html@npm:1.0.3"
@@ -1194,6 +1338,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fast-safe-stringify@npm:^2.1.1":
+  version: 2.1.1
+  resolution: "fast-safe-stringify@npm:2.1.1"
+  checksum: 10c0/d90ec1c963394919828872f21edaa3ad6f1dddd288d2bd4e977027afff09f5db40f94e39536d4646f7e01761d704d72d51dce5af1b93717f3489ef808f5f4e4d
+  languageName: node
+  linkType: hard
+
 "fdir@npm:^6.4.4, fdir@npm:^6.5.0":
   version: 6.5.0
   resolution: "fdir@npm:6.5.0"
@@ -1234,6 +1385,30 @@ __metadata:
     cross-spawn: "npm:^7.0.6"
     signal-exit: "npm:^4.0.1"
   checksum: 10c0/8986e4af2430896e65bc2788d6679067294d6aee9545daefc84923a0a4b399ad9c7a3ea7bd8c0b2b80fdf4a92de4c69df3f628233ff3224260e9c1541a9e9ed3
+  languageName: node
+  linkType: hard
+
+"form-data@npm:^4.0.0, form-data@npm:^4.0.5":
+  version: 4.0.5
+  resolution: "form-data@npm:4.0.5"
+  dependencies:
+    asynckit: "npm:^0.4.0"
+    combined-stream: "npm:^1.0.8"
+    es-set-tostringtag: "npm:^2.1.0"
+    hasown: "npm:^2.0.2"
+    mime-types: "npm:^2.1.12"
+  checksum: 10c0/dd6b767ee0bbd6d84039db12a0fa5a2028160ffbfaba1800695713b46ae974a5f6e08b3356c3195137f8530dcd9dfcb5d5ae1eeff53d0db1e5aad863b619ce3b
+  languageName: node
+  linkType: hard
+
+"formidable@npm:^3.5.4":
+  version: 3.5.4
+  resolution: "formidable@npm:3.5.4"
+  dependencies:
+    "@paralleldrive/cuid2": "npm:^2.2.2"
+    dezalgo: "npm:^1.0.4"
+    once: "npm:^1.4.0"
+  checksum: 10c0/3a311ce57617eb8f532368e91c0f2bbfb299a0f1a35090e085bd6ca772298f196fbb0b66f0d4b5549d7bf3c5e1844439338d4402b7b6d1fedbe206ad44a931f8
   languageName: node
   linkType: hard
 
@@ -1293,6 +1468,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"generator-function@npm:^2.0.0":
+  version: 2.0.1
+  resolution: "generator-function@npm:2.0.1"
+  checksum: 10c0/8a9f59df0f01cfefafdb3b451b80555e5cf6d76487095db91ac461a0e682e4ff7a9dbce15f4ecec191e53586d59eece01949e05a4b4492879600bbbe8e28d6b8
+  languageName: node
+  linkType: hard
+
 "get-intrinsic@npm:^1.2.5, get-intrinsic@npm:^1.3.0":
   version: 1.3.0
   resolution: "get-intrinsic@npm:1.3.0"
@@ -1308,6 +1490,27 @@ __metadata:
     hasown: "npm:^2.0.2"
     math-intrinsics: "npm:^1.1.0"
   checksum: 10c0/52c81808af9a8130f581e6a6a83e1ba4a9f703359e7a438d1369a5267a25412322f03dcbd7c549edaef0b6214a0630a28511d7df0130c93cfd380f4fa0b5b66a
+  languageName: node
+  linkType: hard
+
+"get-intrinsic@npm:^1.2.6":
+  version: 1.3.1
+  resolution: "get-intrinsic@npm:1.3.1"
+  dependencies:
+    async-function: "npm:^1.0.0"
+    async-generator-function: "npm:^1.0.0"
+    call-bind-apply-helpers: "npm:^1.0.2"
+    es-define-property: "npm:^1.0.1"
+    es-errors: "npm:^1.3.0"
+    es-object-atoms: "npm:^1.1.1"
+    function-bind: "npm:^1.1.2"
+    generator-function: "npm:^2.0.0"
+    get-proto: "npm:^1.0.1"
+    gopd: "npm:^1.2.0"
+    has-symbols: "npm:^1.1.0"
+    hasown: "npm:^2.0.2"
+    math-intrinsics: "npm:^1.1.0"
+  checksum: 10c0/9f4ab0cf7efe0fd2c8185f52e6f637e708f3a112610c88869f8f041bb9ecc2ce44bf285dfdbdc6f4f7c277a5b88d8e94a432374d97cca22f3de7fc63795deb5d
   languageName: node
   linkType: hard
 
@@ -1365,10 +1568,19 @@ __metadata:
   languageName: node
   linkType: hard
 
-"has-symbols@npm:^1.1.0":
+"has-symbols@npm:^1.0.3, has-symbols@npm:^1.1.0":
   version: 1.1.0
   resolution: "has-symbols@npm:1.1.0"
   checksum: 10c0/dde0a734b17ae51e84b10986e651c664379018d10b91b6b0e9b293eddb32f0f069688c841fb40f19e9611546130153e0a2a48fd7f512891fb000ddfa36f5a20e
+  languageName: node
+  linkType: hard
+
+"has-tostringtag@npm:^1.0.2":
+  version: 1.0.2
+  resolution: "has-tostringtag@npm:1.0.2"
+  dependencies:
+    has-symbols: "npm:^1.0.3"
+  checksum: 10c0/a8b166462192bafe3d9b6e420a1d581d93dd867adb61be223a17a8d6dad147aa77a8be32c961bb2f27b3ef893cae8d36f564ab651f5e9b7938ae86f74027c48c
   languageName: node
   linkType: hard
 
@@ -1758,10 +1970,33 @@ __metadata:
   languageName: node
   linkType: hard
 
+"methods@npm:^1.1.2":
+  version: 1.1.2
+  resolution: "methods@npm:1.1.2"
+  checksum: 10c0/bdf7cc72ff0a33e3eede03708c08983c4d7a173f91348b4b1e4f47d4cdbf734433ad971e7d1e8c77247d9e5cd8adb81ea4c67b0a2db526b758b2233d7814b8b2
+  languageName: node
+  linkType: hard
+
+"mime-db@npm:1.52.0":
+  version: 1.52.0
+  resolution: "mime-db@npm:1.52.0"
+  checksum: 10c0/0557a01deebf45ac5f5777fe7740b2a5c309c6d62d40ceab4e23da9f821899ce7a900b7ac8157d4548ddbb7beffe9abc621250e6d182b0397ec7f10c7b91a5aa
+  languageName: node
+  linkType: hard
+
 "mime-db@npm:^1.54.0":
   version: 1.54.0
   resolution: "mime-db@npm:1.54.0"
   checksum: 10c0/8d907917bc2a90fa2df842cdf5dfeaf509adc15fe0531e07bb2f6ab15992416479015828d6a74200041c492e42cce3ebf78e5ce714388a0a538ea9c53eece284
+  languageName: node
+  linkType: hard
+
+"mime-types@npm:^2.1.12":
+  version: 2.1.35
+  resolution: "mime-types@npm:2.1.35"
+  dependencies:
+    mime-db: "npm:1.52.0"
+  checksum: 10c0/82fb07ec56d8ff1fc999a84f2f217aa46cb6ed1033fefaabd5785b9a974ed225c90dc72fff460259e66b95b73648596dbcc50d51ed69cdf464af2d237d3149b2
   languageName: node
   linkType: hard
 
@@ -1771,6 +2006,15 @@ __metadata:
   dependencies:
     mime-db: "npm:^1.54.0"
   checksum: 10c0/bd8c20d3694548089cf229016124f8f40e6a60bbb600161ae13e45f793a2d5bb40f96bbc61f275836696179c77c1d6bf4967b2a75e0a8ad40fe31f4ed5be4da5
+  languageName: node
+  linkType: hard
+
+"mime@npm:2.6.0":
+  version: 2.6.0
+  resolution: "mime@npm:2.6.0"
+  bin:
+    mime: cli.js
+  checksum: 10c0/a7f2589900d9c16e3bdf7672d16a6274df903da958c1643c9c45771f0478f3846dcb1097f31eb9178452570271361e2149310931ec705c037210fc69639c8e6c
   languageName: node
   linkType: hard
 
@@ -2150,6 +2394,15 @@ __metadata:
   languageName: node
   linkType: hard
 
+"qs@npm:^6.14.1":
+  version: 6.15.2
+  resolution: "qs@npm:6.15.2"
+  dependencies:
+    side-channel: "npm:^1.1.0"
+  checksum: 10c0/e6fd5f6f0aab06d480fe9ab15cebfc4ce4235303e2f91dc69a8f7f4df1e668a61c11d1cfbabacf4295cbbeb7b670ed23db45307480726259761f98e5695e93a7
+  languageName: node
+  linkType: hard
+
 "range-parser@npm:^1.2.1":
   version: 1.2.1
   resolution: "range-parser@npm:1.2.1"
@@ -2344,12 +2597,14 @@ __metadata:
     "@types/dotenv": "npm:^8.2.3"
     "@types/express": "npm:^5.0.3"
     "@types/node": "npm:^24.2.1"
+    "@types/supertest": "npm:^7.2.0"
     "@vitest/coverage-v8": "npm:^4.1.6"
     better-sqlite3: "npm:^12.10.0"
     cors: "npm:^2.8.5"
     dotenv: "npm:^17.2.1"
     express: "npm:^5.1.0"
     express-rate-limit: "npm:^8.0.1"
+    supertest: "npm:^7.2.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.2"
     uuid: "npm:^11.1.0"
@@ -2585,6 +2840,34 @@ __metadata:
   version: 2.0.1
   resolution: "strip-json-comments@npm:2.0.1"
   checksum: 10c0/b509231cbdee45064ff4f9fd73609e2bcc4e84a4d508e9dd0f31f70356473fde18abfb5838c17d56fb236f5a06b102ef115438de0600b749e818a35fbbc48c43
+  languageName: node
+  linkType: hard
+
+"superagent@npm:^10.3.0":
+  version: 10.3.0
+  resolution: "superagent@npm:10.3.0"
+  dependencies:
+    component-emitter: "npm:^1.3.1"
+    cookiejar: "npm:^2.1.4"
+    debug: "npm:^4.3.7"
+    fast-safe-stringify: "npm:^2.1.1"
+    form-data: "npm:^4.0.5"
+    formidable: "npm:^3.5.4"
+    methods: "npm:^1.1.2"
+    mime: "npm:2.6.0"
+    qs: "npm:^6.14.1"
+  checksum: 10c0/7792ec2ba3a877eb1db57ad9149bf0e108688a40af0e75084bdc4bba82604b7962248267159565be4f5ab8aa392f1285a08d2e5a8cb2c3b0a51932499caf6ee6
+  languageName: node
+  linkType: hard
+
+"supertest@npm:^7.2.2":
+  version: 7.2.2
+  resolution: "supertest@npm:7.2.2"
+  dependencies:
+    cookie-signature: "npm:^1.2.2"
+    methods: "npm:^1.1.2"
+    superagent: "npm:^10.3.0"
+  checksum: 10c0/9de987aefbec50c5dfac79ff699bbc23c89cdbfe59ede165309fb3cf00c306117b30c5059fe6f7085c7525aab315ac27c77a1dc6056b993c7e0bb154a56c2b78
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Add HTTP-level integration tests for the Express API, driven by Supertest against the real router and middleware with an in-memory SQLite database.

- Extract the Express app into app.ts so it can be driven without binding a port; index.ts now imports it
- testServer.ts: one listening server per test file, reused across requests
- Skip the request logger under NODE_ENV=test
- Tests:
  - auth: admin login and the auth guard on every admin route
  - events: create/list/get/update/delete, validation, serverTime, cascade delete, and capacity edge cases
  - rsvps: create/update/delete, token-scoped edits, the registration window, and /rsvps/my
  - polls: create/close/reopen/update/delete, voting, and option cascade
  - adversarial: SQL-injection safety, token/identity (IDOR) isolation, and the request body-size boundary
- Add supertest and @types/supertest
- README: document the unit and integration suites

Several tests characterize current behavior and flag known issues in comments for follow-up: missing whitespace/guest validation, duplicate polls per event, cross-event voting, a 500 on duplicate optionIds, the token field returned by updateRsvpByToken, and a 500 (not 413) on oversized bodies.