### PR TITLE
Remove unused express-rate-limit dependency

### DIFF
--- a/server/package.json
+++ b/server/package.json
@@ -7,7 +7,6 @@
     "cors": "^2.8.5",
     "dotenv": "^17.2.1",
     "express": "^5.1.0",
-    "express-rate-limit": "^8.0.1",
     "uuid": "^11.1.0"
   },
   "devDependencies": {

--- a/server/yarn.lock
+++ b/server/yarn.lock
@@ -1292,17 +1292,6 @@ __metadata:
   languageName: node
   linkType: hard
 
-"express-rate-limit@npm:^8.0.1":
-  version: 8.0.1
-  resolution: "express-rate-limit@npm:8.0.1"
-  dependencies:
-    ip-address: "npm:10.0.1"
-  peerDependencies:
-    express: ">= 4.11"
-  checksum: 10c0/c3cca4a87c6839e3ed94617405091e80ecbcc7200e34495aeedc48c819ce1ca7073d522706e46369cc252b8df0364ae5ff181f4ae75e75cbbe9adf3f19ec6666
-  languageName: node
-  linkType: hard
-
 "express@npm:^5.1.0":
   version: 5.1.0
   resolution: "express@npm:5.1.0"
@@ -1677,7 +1666,7 @@ __metadata:
   languageName: node
   linkType: hard
 
-"ip-address@npm:10.0.1, ip-address@npm:^10.0.1":
+"ip-address@npm:^10.0.1":
   version: 10.0.1
   resolution: "ip-address@npm:10.0.1"
   checksum: 10c0/1634d79dae18394004775cb6d699dc46b7c23df6d2083164025a2b15240c1164fccde53d0e08bd5ee4fc53913d033ab6b5e395a809ad4b956a940c446e948843
@@ -2603,7 +2592,6 @@ __metadata:
     cors: "npm:^2.8.5"
     dotenv: "npm:^17.2.1"
     express: "npm:^5.1.0"
-    express-rate-limit: "npm:^8.0.1"
     supertest: "npm:^7.2.2"
     ts-node: "npm:^10.9.2"
     typescript: "npm:^5.9.2"


### PR DESCRIPTION
The middleware was removed in b37da72 but the dependency was left behind.