### PR TITLE
Serve events as .ics files so Add to Calendar works on iOS

### DIFF
--- a/client/e2e/add-to-calendar.spec.ts
+++ b/client/e2e/add-to-calendar.spec.ts
@@ -1,0 +1,70 @@
+import { expect, test, type APIRequestContext } from '@playwright/test';
+
+const API = 'http://localhost:3000';
+const AUTH = 'Basic e2eadmin:e2epass';
+
+async function createEvent(request: APIRequestContext) {
+  const res = await request.post(`${API}/admin/create-event`, {
+    headers: { Authorization: AUTH },
+    data: {
+      name: 'E2E Calendar Event',
+      date: '2099-12-25',
+      startTime: '18:00',
+      endTime: '22:00',
+      location: 'Test Venue, Berlin',
+    },
+  });
+  const body = await res.json();
+  return body.event.id as string;
+}
+
+// The calendar button used to build a data: URL in the browser, which iOS
+// Safari 26.6+ silently refuses. It now points at the API's .ics endpoint, so
+// what matters end to end is that the advertised URL exists and serves a
+// calendar file the browser will hand to a calendar app.
+test.describe('Add to Calendar', () => {
+  test('advertises an .ics URL for the event', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    const button = page.locator('add-to-calendar-button');
+    await expect(button).toHaveAttribute('icsFile', `${API}/events/${eventId}/calendar.ics`);
+  });
+
+  test('the advertised URL serves a calendar file for the event', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    const icsUrl = await page.locator('add-to-calendar-button').getAttribute('icsFile');
+    expect(icsUrl).toBeTruthy();
+
+    const res = await request.get(icsUrl as string);
+    expect(res.status()).toBe(200);
+    expect(res.headers()['content-type']).toBe('text/calendar; charset=utf-8');
+
+    const body = await res.text();
+    expect(body).toContain('BEGIN:VCALENDAR');
+    expect(body).toContain('SUMMARY:E2E Calendar Event');
+    expect(body).toContain('LOCATION:Test Venue\\, Berlin');
+    expect(body).toContain('DTSTART;TZID=Europe/Berlin:20991225T180000');
+    expect(body).toContain('DTEND;TZID=Europe/Berlin:20991225T220000');
+  });
+
+  test('choosing Apple hands a calendar file to the browser', async ({ page, request }) => {
+    const eventId = await createEvent(request);
+    await page.goto(`/events/${eventId}`);
+
+    // The button renders into a shadow root; Playwright's CSS engine pierces it.
+    await page.locator('add-to-calendar-button').getByText('Add to Calendar').click();
+
+    const appleOption = page.locator('[id$="-apple"]');
+    await expect(appleOption).toBeVisible();
+
+    const downloadPromise = page.waitForEvent('download');
+    await appleOption.click();
+    const download = await downloadPromise;
+
+    expect(download.suggestedFilename()).toMatch(/\.ics$/);
+    expect(download.url()).toBe(`${API}/events/${eventId}/calendar.ics`);
+  });
+});

--- a/client/package.json
+++ b/client/package.json
@@ -50,6 +50,6 @@
     "wrangler": "^4.30.0"
   },
   "dependencies": {
-    "add-to-calendar-button": "^2.12.12"
+    "add-to-calendar-button": "^2.15.0"
   }
 }

--- a/client/src/__tests__/routes/EventDetailPage.test.ts
+++ b/client/src/__tests__/routes/EventDetailPage.test.ts
@@ -302,6 +302,51 @@ describe('EventDetailPage — multi-user "Editing For" select', () => {
   });
 });
 
+// iOS Safari 26.6+ ignores the data: URL the calendar button builds by default,
+// so the button has to be pointed at the API's .ics endpoint instead.
+describe('EventDetailPage — Add to Calendar', () => {
+  beforeEach(() => stubFetchUnauthorized());
+
+  async function renderCalendarButton(event: Event = baseEvent) {
+    // Built inline rather than via buildData, which widens event to Event | null.
+    const data = { event, rsvp: [] as Rsvp[], poll: null, clockOffset: 0 };
+    const { container } = render(EventDetailPage, { props: { data } });
+    return await waitFor(() => {
+      const button = container.querySelector('add-to-calendar-button');
+      expect(button).not.toBeNull();
+      return button as HTMLElement;
+    });
+  }
+
+  it('points the button at the .ics endpoint for this event', async () => {
+    const button = await renderCalendarButton();
+
+    expect(button.getAttribute('icsFile')).toBe('http://localhost:3000/events/evt-1/calendar.ics');
+  });
+
+  it('offers Apple among the calendar options', async () => {
+    const button = await renderCalendarButton();
+
+    expect(button.getAttribute('options')).toContain('Apple');
+  });
+
+  it('passes the event details through to the button', async () => {
+    const button = await renderCalendarButton();
+
+    expect(button.getAttribute('name')).toBe('Board Game Night');
+    expect(button.getAttribute('startDate')).toBe('2024-06-15');
+    expect(button.getAttribute('startTime')).toBe('19:00');
+    expect(button.getAttribute('endTime')).toBe('22:00');
+    expect(button.getAttribute('location')).toBe('The Pub, Berlin');
+  });
+
+  it('defaults the end time to one hour after the start', async () => {
+    const button = await renderCalendarButton({ ...baseEvent, end_time: undefined });
+
+    expect(button.getAttribute('endTime')).toBe('20:00');
+  });
+});
+
 describe('EventDetailPage — XSS safety', () => {
   beforeEach(() => stubFetchUnauthorized());
 

--- a/client/src/routes/events/[id]/+page.svelte
+++ b/client/src/routes/events/[id]/+page.svelte
@@ -265,6 +265,7 @@
           endTime={event.end_time ?? addOneHour(event.start_time)}
           timeZone="Europe/Berlin"
           location={event.location}
+          icsFile="{API_HOST}/events/{event.id}/calendar.ics"
           options="['Google', 'Apple', 'iCal', 'Microsoft365', 'MicrosoftTeams', 'Outlook.com', 'Yahoo']"
           label="Add to Calendar"
           hideBranding="True"

--- a/client/yarn.lock
+++ b/client/yarn.lock
@@ -2167,12 +2167,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"add-to-calendar-button@npm:^2.12.12":
-  version: 2.12.12
-  resolution: "add-to-calendar-button@npm:2.12.12"
+"add-to-calendar-button@npm:^2.15.0":
+  version: 2.15.0
+  resolution: "add-to-calendar-button@npm:2.15.0"
   dependencies:
-    timezones-ical-library: "npm:^1.10.0"
-  checksum: 10c0/2465bb20aa3ed7cc90086b304d57e77fa764851ba287ecc56fd4b5b651d5e264b3b887b870fde3d16809f35953f11c5a6a65d79d102011d9fb01a28730648388
+    timezones-ical-library: "npm:^2.2.1"
+  checksum: 10c0/8d99cc7c4c8ee6ce115338cc9406dbd18f9ce51ea69d9c2e2c8cb52db606131079076f8f39160bcfc21d6aeac90c596b24ea8de0f19cabb666e05e618ee8b87d
   languageName: node
   linkType: hard
 
@@ -2407,7 +2407,7 @@ __metadata:
     "@testing-library/jest-dom": "npm:^6.9.1"
     "@testing-library/svelte": "npm:^5.3.1"
     "@vitest/coverage-v8": "npm:^4.1.6"
-    add-to-calendar-button: "npm:^2.12.12"
+    add-to-calendar-button: "npm:^2.15.0"
     eslint: "npm:^9.18.0"
     eslint-config-prettier: "npm:^10.0.1"
     eslint-plugin-svelte: "npm:^3.0.0"
@@ -5226,10 +5226,10 @@ __metadata:
   languageName: node
   linkType: hard
 
-"timezones-ical-library@npm:^1.10.0":
-  version: 1.10.0
-  resolution: "timezones-ical-library@npm:1.10.0"
-  checksum: 10c0/69938d33dbde178cc2332d64f8645859189804db95de7423f5a54900cbff250f865b4e057b10da1395ddd6fc57c52c91220bf2ee90c1bcf0a31bda803e541888
+"timezones-ical-library@npm:^2.2.1":
+  version: 2.3.1
+  resolution: "timezones-ical-library@npm:2.3.1"
+  checksum: 10c0/6c0c32ea0187fa2c5e343fe76c5aafeb4b73b1a629128b8769eb10ae0562784cb226e2293466b564f6e1df4242655d67c8fad92dabcf07b4ab775f7d7d0e8035
   languageName: node
   linkType: hard
 

--- a/server/src/__tests__/integration/events.test.ts
+++ b/server/src/__tests__/integration/events.test.ts
@@ -132,6 +132,102 @@ describe('GET /events/:id', () => {
   });
 });
 
+describe('GET /events/:id/calendar.ics', () => {
+  async function createEvent(body: Record<string, unknown> = BASE_BODY) {
+    const res = await request(server)
+      .post('/admin/create-event')
+      .set('Authorization', AUTH)
+      .send(body);
+    return res.body.event.id as string;
+  }
+
+  it('serves the event as a calendar file', async () => {
+    const id = await createEvent();
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.headers['content-type']).toBe('text/calendar; charset=utf-8');
+    expect(res.text).toContain('BEGIN:VCALENDAR');
+    expect(res.text).toContain('END:VCALENDAR');
+    expect(res.text).toContain('SUMMARY:Test Event');
+    expect(res.text).toContain('LOCATION:Test Venue');
+    expect(res.text).toContain(`UID:${id}`);
+  });
+
+  it('qualifies the times with the event time zone', async () => {
+    const id = await createEvent();
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.text).toContain('DTSTART;TZID=Europe/Berlin:20251225T180000');
+    expect(res.text).toContain('DTEND;TZID=Europe/Berlin:20251225T220000');
+    expect(res.text).toContain('BEGIN:VTIMEZONE');
+  });
+
+  // iOS opens the calendar preview only when the file is served plainly; an
+  // attachment disposition would turn it into a download instead.
+  it('does not mark the file as an attachment', async () => {
+    const id = await createEvent();
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.headers['content-disposition']).toBeUndefined();
+    expect(res.headers['cache-control']).toBe('no-cache');
+  });
+
+  it('uses CRLF line endings', async () => {
+    const id = await createEvent();
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.text).toContain('\r\n');
+    expect(res.text.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+
+  it('reflects an updated event', async () => {
+    const id = await createEvent();
+
+    await request(server)
+      .patch(`/admin/events/${id}`)
+      .set('Authorization', AUTH)
+      .send({ name: 'Renamed Event', startTime: '20:00' })
+      .expect(200);
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.text).toContain('SUMMARY:Renamed Event');
+    expect(res.text).toContain('DTSTART;TZID=Europe/Berlin:20251225T200000');
+  });
+
+  // Events predating the required endTime validation still have NULL end_time.
+  it('falls back to a one hour event when the row has no end time', async () => {
+    const id = await createEvent();
+    db.prepare('UPDATE events SET end_time = NULL WHERE id = ?').run(id);
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.text).toContain('DTSTART;TZID=Europe/Berlin:20251225T180000');
+    expect(res.text).toContain('DTEND;TZID=Europe/Berlin:20251225T190000');
+  });
+
+  it('escapes characters that would break the calendar format', async () => {
+    const id = await createEvent({
+      ...BASE_BODY,
+      name: 'Pizza, beer; and games',
+      location: 'Back;room, upstairs',
+    });
+
+    const res = await request(server).get(`/events/${id}/calendar.ics`).expect(200);
+
+    expect(res.text).toContain('SUMMARY:Pizza\\, beer\\; and games');
+    expect(res.text).toContain('LOCATION:Back\\;room\\, upstairs');
+  });
+
+  it('returns 404 for a non-existent event', async () => {
+    await request(server).get('/events/no-such-id/calendar.ics').expect(404);
+  });
+});
+
 describe('GET /events/:id — serverTime', () => {
   it('serverTime is a number close to Date.now()', async () => {
     const created = await request(server)

--- a/server/src/__tests__/unit/utils/generateIcs.test.ts
+++ b/server/src/__tests__/unit/utils/generateIcs.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest';
+import { generateIcs } from '../../../utils/generateIcs';
+
+const now = new Date('2026-08-03T12:00:00.000Z');
+
+const baseEvent = {
+  id: 'abc-123',
+  name: 'Board Game Night',
+  date: '2027-02-26',
+  startTime: '19:00',
+  endTime: '22:30',
+  location: 'Tales Untold',
+  createdAt: '2026-08-01T10:00:00.000Z',
+};
+
+function lines(ics: string): string[] {
+  return ics.split('\r\n');
+}
+
+describe('generateIcs', () => {
+  it('wraps the event in a VCALENDAR with a VEVENT', () => {
+    const result = lines(generateIcs(baseEvent, now));
+
+    expect(result[0]).toBe('BEGIN:VCALENDAR');
+    expect(result.at(-1)).toBe('END:VCALENDAR');
+    expect(result).toContain('BEGIN:VEVENT');
+    expect(result).toContain('END:VEVENT');
+    expect(result).toContain('VERSION:2.0');
+    expect(result).toContain('METHOD:PUBLISH');
+  });
+
+  it('uses CRLF line endings, as iCalendar requires', () => {
+    const ics = generateIcs(baseEvent, now);
+
+    expect(ics).toContain('\r\n');
+    expect(ics.replace(/\r\n/g, '')).not.toContain('\n');
+  });
+
+  it('emits start and end times qualified with the event time zone', () => {
+    const result = lines(generateIcs(baseEvent, now));
+
+    expect(result).toContain('DTSTART;TZID=Europe/Berlin:20270226T190000');
+    expect(result).toContain('DTEND;TZID=Europe/Berlin:20270226T223000');
+    expect(result).toContain('BEGIN:VTIMEZONE');
+    expect(result).toContain('TZID:Europe/Berlin');
+  });
+
+  it('defaults the end time to one hour after the start', () => {
+    const result = lines(generateIcs({ ...baseEvent, endTime: null }, now));
+
+    expect(result).toContain('DTEND;TZID=Europe/Berlin:20270226T200000');
+  });
+
+  it('wraps a start time late in the day around midnight', () => {
+    const result = lines(
+      generateIcs({ ...baseEvent, startTime: '23:30', endTime: null }, now),
+    );
+
+    expect(result).toContain('DTEND;TZID=Europe/Berlin:20270226T003000');
+  });
+
+  it('stamps the current time as DTSTAMP', () => {
+    const result = lines(generateIcs(baseEvent, now));
+
+    expect(result).toContain('DTSTAMP:20260803T120000Z');
+    expect(result).toContain('CREATED:20260801T100000Z');
+  });
+
+  it('falls back to the current time when the event has no created date', () => {
+    const result = lines(generateIcs({ ...baseEvent, createdAt: null }, now));
+
+    expect(result).toContain('CREATED:20260803T120000Z');
+  });
+
+  it('uses the event id as the UID', () => {
+    const result = lines(generateIcs(baseEvent, now));
+
+    expect(result).toContain('UID:abc-123');
+  });
+
+  it('escapes characters that iCalendar treats as syntax', () => {
+    const result = generateIcs(
+      { ...baseEvent, name: 'Pizza, beer; and games', location: 'Back\\room' },
+      now,
+    );
+
+    expect(result).toContain('SUMMARY:Pizza\\, beer\\; and games');
+    expect(result).toContain('LOCATION:Back\\\\room');
+  });
+
+  it('omits LOCATION when the event has none', () => {
+    const result = lines(generateIcs({ ...baseEvent, location: null }, now));
+
+    // X-LIC-LOCATION in the VTIMEZONE block is a different property.
+    expect(result.some((line) => line.startsWith('LOCATION:'))).toBe(false);
+  });
+
+  it('folds content lines longer than 75 octets', () => {
+    const ics = generateIcs({ ...baseEvent, name: 'A'.repeat(200) }, now);
+
+    for (const line of lines(ics)) {
+      expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(75);
+    }
+    // Continuation lines start with a single space and rejoin to the original.
+    expect(ics).toContain('\r\n ');
+    expect(ics.replace(/\r\n /g, '')).toContain(`SUMMARY:${'A'.repeat(200)}`);
+  });
+
+  it('folds without splitting multi-byte characters', () => {
+    const ics = generateIcs({ ...baseEvent, name: '🎲'.repeat(40) }, now);
+
+    for (const line of lines(ics)) {
+      expect(Buffer.byteLength(line, 'utf8')).toBeLessThanOrEqual(75);
+    }
+    expect(ics.replace(/\r\n /g, '')).toContain(`SUMMARY:${'🎲'.repeat(40)}`);
+  });
+});

--- a/server/src/controllers/eventController.ts
+++ b/server/src/controllers/eventController.ts
@@ -2,6 +2,7 @@ import { Request, Response } from "express";
 import { createEvent as createEventService, getEventById as getEventByIdService, getAllEvents as getAllEventsService, deleteEvent as deleteEventService, updateEvent as updateEventService } from "../services/event";
 import { getRsvpByEventId } from '../services/rsvp';
 import { getPollByEventId } from '../services/poll';
+import { generateIcs } from '../utils/generateIcs';
 
 export const createEvent = async (req: Request, res: Response, next: Function) => {
   const { name, date, startTime, endTime, maxAttendees, location, registrationOpensAt } = req.body;
@@ -34,6 +35,49 @@ export const getEventById = async (req: Request, res: Response, next: Function) 
     const attendees = await getRsvpByEventId(id);
     const poll = getPollByEventId(id);
     res.status(200).json({ event, rsvp: attendees, poll, serverTime: Date.now() });
+  } catch (err) {
+    next(err);
+  }
+};
+
+// Serves the event as a real .ics file. iOS Safari 26.6+ ignores the
+// data:text/calendar URL the calendar button builds by default, so the client
+// points its icsFile option here instead.
+export const getEventCalendar = async (req: Request, res: Response, next: Function) => {
+  try {
+    const { id } = req.params;
+
+    const event = await getEventByIdService(id);
+    if (!event) {
+      return res.status(404).json({ error: "Event not found" });
+    }
+
+    // Rows come back with the database's snake_case column names.
+    const row = event as unknown as {
+      id: string;
+      name: string;
+      date: string;
+      start_time: string;
+      end_time?: string | null;
+      location?: string | null;
+      created_at?: string | null;
+    };
+
+    const ics = generateIcs({
+      id: row.id,
+      name: row.name,
+      date: row.date,
+      startTime: row.start_time,
+      endTime: row.end_time,
+      location: row.location,
+      createdAt: row.created_at,
+    });
+
+    // No Content-Disposition: iOS opens the calendar preview when the file is
+    // served plainly, and an attachment disposition would force a download.
+    res.setHeader("Content-Type", "text/calendar; charset=utf-8");
+    res.setHeader("Cache-Control", "no-cache");
+    res.status(200).send(ics);
   } catch (err) {
     next(err);
   }
@@ -81,6 +125,7 @@ export const deleteEvent = async (req: Request, res: Response, next: Function) =
 export const eventController = {
   createEvent,
   getEventById,
+  getEventCalendar,
   getAllEvents,
   updateEvent,
   deleteEvent,

--- a/server/src/routes.ts
+++ b/server/src/routes.ts
@@ -21,6 +21,7 @@ router.delete("/admin/polls/:id", authenticateAdmin, pollController.deletePollCo
 
 // Public routes
 router.get("/events/:id", eventController.getEventById);
+router.get("/events/:id/calendar.ics", eventController.getEventCalendar);
 router.post("/events/:id/rsvp", rsvpController.rsvpToEvent);
 router.patch("/events/:id/rsvp/:rsvpId", rsvpController.updateRsvpByTokenController);
 router.post("/rsvps/my", rsvpController.getMyRsvps);

--- a/server/src/utils/generateIcs.ts
+++ b/server/src/utils/generateIcs.ts
@@ -1,0 +1,113 @@
+// Builds an iCalendar file for an event.
+//
+// This exists because iOS Safari 26.6 and later refuse to hand a
+// `data:text/calendar` URL to the Calendar app — the add-to-calendar-button
+// library's default mechanism, which silently does nothing on those versions.
+// Serving the same content from a real URL works, so the client points the
+// library's `icsFile` option at this endpoint.
+
+// The client renders every event in this zone, so the ICS has to match.
+const TIME_ZONE = 'Europe/Berlin';
+
+// Standard EU daylight saving rules for Europe/Berlin.
+const VTIMEZONE = [
+  'BEGIN:VTIMEZONE',
+  `TZID:${TIME_ZONE}`,
+  `X-LIC-LOCATION:${TIME_ZONE}`,
+  'BEGIN:DAYLIGHT',
+  'TZNAME:CEST',
+  'TZOFFSETFROM:+0100',
+  'TZOFFSETTO:+0200',
+  'DTSTART:19700329T020000',
+  'RRULE:FREQ=YEARLY;BYMONTH=3;BYDAY=-1SU',
+  'END:DAYLIGHT',
+  'BEGIN:STANDARD',
+  'TZNAME:CET',
+  'TZOFFSETFROM:+0200',
+  'TZOFFSETTO:+0100',
+  'DTSTART:19701025T030000',
+  'RRULE:FREQ=YEARLY;BYMONTH=10;BYDAY=-1SU',
+  'END:STANDARD',
+  'END:VTIMEZONE',
+];
+
+export type IcsEventInput = {
+  id: string;
+  name: string;
+  date: string; // YYYY-MM-DD
+  startTime: string; // HH:mm
+  endTime?: string | null; // HH:mm, defaults to one hour after startTime
+  location?: string | null;
+  createdAt?: string | null;
+};
+
+// Escapes the characters iCalendar treats as syntax within a text value.
+function escapeText(value: string): string {
+  return value
+    .replace(/\\/g, '\\\\')
+    .replace(/;/g, '\\;')
+    .replace(/,/g, '\\,')
+    .replace(/\r?\n/g, '\\n');
+}
+
+// RFC 5545 limits content lines to 75 octets, continued with a leading space.
+function foldLine(line: string): string {
+  if (Buffer.byteLength(line, 'utf8') <= 75) return line;
+
+  const parts: string[] = [];
+  let current = '';
+  for (const char of line) {
+    // Continuation lines carry a leading space, so they get one octet less.
+    const limit = parts.length === 0 ? 75 : 74;
+    if (Buffer.byteLength(current + char, 'utf8') > limit) {
+      parts.push(current);
+      current = '';
+    }
+    current += char;
+  }
+  parts.push(current);
+  return parts.join('\r\n ');
+}
+
+function addOneHour(time: string): string {
+  const [hours, minutes] = time.split(':').map(Number);
+  return `${String((hours + 1) % 24).padStart(2, '0')}:${String(minutes).padStart(2, '0')}`;
+}
+
+// YYYY-MM-DD + HH:mm -> YYYYMMDDTHHMMSS (local to TIME_ZONE, no trailing Z)
+function toIcsLocalTime(date: string, time: string): string {
+  return `${date.replace(/-/g, '')}T${time.replace(/:/g, '')}00`;
+}
+
+// Date -> YYYYMMDDTHHMMSSZ
+function toIcsUtcTime(value: Date): string {
+  return `${value.toISOString().replace(/[-:]/g, '').split('.')[0]}Z`;
+}
+
+export function generateIcs(event: IcsEventInput, now: Date = new Date()): string {
+  const endTime = event.endTime || addOneHour(event.startTime);
+  const created = event.createdAt ? new Date(event.createdAt) : now;
+
+  const lines = [
+    'BEGIN:VCALENDAR',
+    'VERSION:2.0',
+    'PRODID:-//event-rsvp-management-tool//EN',
+    'CALSCALE:GREGORIAN',
+    'METHOD:PUBLISH',
+    ...VTIMEZONE,
+    'BEGIN:VEVENT',
+    `UID:${event.id}`,
+    `DTSTAMP:${toIcsUtcTime(now)}`,
+    `DTSTART;TZID=${TIME_ZONE}:${toIcsLocalTime(event.date, event.startTime)}`,
+    `DTEND;TZID=${TIME_ZONE}:${toIcsLocalTime(event.date, endTime)}`,
+    `SUMMARY:${escapeText(event.name)}`,
+    ...(event.location ? [`LOCATION:${escapeText(event.location)}`] : []),
+    'SEQUENCE:0',
+    'STATUS:CONFIRMED',
+    `CREATED:${toIcsUtcTime(created)}`,
+    'END:VEVENT',
+    'END:VCALENDAR',
+  ];
+
+  return lines.map(foldLine).join('\r\n');
+}


### PR DESCRIPTION
iOS Safari 26.6 and later ignore the data:text/calendar URL that
add-to-calendar-button hands to the Calendar app, so tapping Apple did
nothing. Reproduced in the iOS 27.0 simulator; iOS 26.5 still works.

Testing each mechanism in isolation showed the data: scheme is the only
broken part - blob: and real URLs both work, including through the
library's detached-anchor-plus-synthetic-click path, and cross-origin.

The likely culprit is WebKit f23ffb5a845006c8efbdf8a18a15f69a617fec00
(bugs.webkit.org 315004, security-restricted), which refuses to turn a
navigation response into a download for data: URLs unless the navigation
came from the API client. It rewrites the action to PolicyAction::Ignore,
which fails silently - exactly what we observed. Its own comment assumes
<a href="data:..." download> takes a different path and stays unaffected;
that does not hold on iOS.

Add GET /events/:id/calendar.ics and point the button's icsFile option at
it. The endpoint mirrors the ICS the library generated, including the
Europe/Berlin VTIMEZONE block, RFC 5545 escaping and line folding.

Also upgrades add-to-calendar-button to 2.15.0.
