### PR TITLE
Fix E2E hydration race that made admin-login flaky on CI

### DIFF
--- a/client/e2e/add-to-calendar.spec.ts
+++ b/client/e2e/add-to-calendar.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test, type APIRequestContext } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -25,7 +26,7 @@ async function createEvent(request: APIRequestContext) {
 test.describe('Add to Calendar', () => {
   test('advertises an .ics URL for the event', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     const button = page.locator('add-to-calendar-button');
     await expect(button).toHaveAttribute('icsFile', `${API}/events/${eventId}/calendar.ics`);
@@ -33,7 +34,7 @@ test.describe('Add to Calendar', () => {
 
   test('the advertised URL serves a calendar file for the event', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     const icsUrl = await page.locator('add-to-calendar-button').getAttribute('icsFile');
     expect(icsUrl).toBeTruthy();
@@ -52,7 +53,7 @@ test.describe('Add to Calendar', () => {
 
   test('choosing Apple hands a calendar file to the browser', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // The button renders into a shadow root; Playwright's CSS engine pierces it.
     await page.locator('add-to-calendar-button').getByText('Add to Calendar').click();

--- a/client/e2e/admin-attendee-delete.spec.ts
+++ b/client/e2e/admin-attendee-delete.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -33,7 +34,7 @@ test.describe('Admin — delete attendee', () => {
     });
     expect(rsvpRes.ok()).toBeTruthy();
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.getByRole('button', { name: /Show Responses/i }).click();
     await expect(page.getByText('Deletable Alice')).toBeVisible();
 
@@ -53,7 +54,7 @@ test.describe('Admin — delete attendee', () => {
       data: { name: 'Delete Me', status: 'going' },
     });
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.getByRole('button', { name: /Show Responses/i }).click();
     await expect(page.getByText('Delete Me')).toBeVisible();
     await expect(page.getByText('Keep Me')).toBeVisible();

--- a/client/e2e/admin-create-event.spec.ts
+++ b/client/e2e/admin-create-event.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 // Log in before each admin test by presetting localStorage credentials
 test.beforeEach(async ({ page }) => {
@@ -11,7 +12,7 @@ test.beforeEach(async ({ page }) => {
 
 test.describe('Admin — create event', () => {
   test('creates an event via the form and shows the event link', async ({ page }) => {
-    await page.goto('/create-event');
+    await gotoHydrated(page, '/create-event');
 
     // Wait for the auth check to complete before filling the form
     await expect(page.getByRole('heading', { name: 'Create Event' })).toBeVisible();
@@ -30,7 +31,7 @@ test.describe('Admin — create event', () => {
   });
 
   test('shows an error when required fields are missing', async ({ page }) => {
-    await page.goto('/create-event');
+    await gotoHydrated(page, '/create-event');
     await expect(page.getByRole('heading', { name: 'Create Event' })).toBeVisible();
 
     // Submit with only name filled in — JS validation fires an alert and returns early

--- a/client/e2e/admin-events.spec.ts
+++ b/client/e2e/admin-events.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -27,7 +28,7 @@ test.describe('Admin — events list', () => {
   });
 
   test('shows unauthorized message when not logged in', async ({ page }) => {
-    await page.goto('/events');
+    await gotoHydrated(page, '/events');
     await expect(page.getByText(/unauthorized/i)).toBeVisible();
   });
 
@@ -36,7 +37,7 @@ test.describe('Admin — events list', () => {
     await page.addInitScript(() => {
       localStorage.setItem('credentials', 'e2eadmin:e2epass');
     });
-    await page.goto('/events');
+    await gotoHydrated(page, '/events');
     await expect(page.getByText('Admin Events Test Event')).toBeVisible();
   });
 
@@ -46,7 +47,7 @@ test.describe('Admin — events list', () => {
       localStorage.setItem('credentials', 'e2eadmin:e2epass');
     });
     page.on('dialog', (dialog) => dialog.accept());
-    await page.goto('/events');
+    await gotoHydrated(page, '/events');
     await expect(page.getByText('Admin Events Test Event')).toBeVisible();
 
     await page.getByRole('button', { name: 'Delete event' }).first().click();
@@ -63,7 +64,7 @@ test.describe('Admin — edit event', () => {
 
   test('can edit an event name', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}/edit`);
+    await gotoHydrated(page, `/events/${eventId}/edit`);
     await expect(page.getByRole('heading', { name: 'Edit Event' })).toBeVisible();
     await page.locator('#name').fill('Updated Event Name');
     await page.click('button[type=submit]');
@@ -74,7 +75,7 @@ test.describe('Admin — edit event', () => {
 
 test.describe('Admin — auth guard', () => {
   test('navigating to /create-event without credentials shows unauthorized state', async ({ page }) => {
-    await page.goto('/create-event');
+    await gotoHydrated(page, '/create-event');
     await expect(page.getByText(/not authorized/i)).toBeVisible();
   });
 });

--- a/client/e2e/admin-login.spec.ts
+++ b/client/e2e/admin-login.spec.ts
@@ -1,8 +1,9 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 test.describe('Admin login', () => {
   test('redirects to /events on valid credentials', async ({ page }) => {
-    await page.goto('/admin/login');
+    await gotoHydrated(page, '/admin/login');
     await page.fill('#name', 'e2eadmin');
     await page.fill('#password', 'e2epass');
     await page.click('button[type=submit]');
@@ -11,7 +12,7 @@ test.describe('Admin login', () => {
   });
 
   test('shows error message for wrong credentials', async ({ page }) => {
-    await page.goto('/admin/login');
+    await gotoHydrated(page, '/admin/login');
     await page.fill('#name', 'e2eadmin');
     await page.fill('#password', 'wrongpass');
     await page.click('button[type=submit]');

--- a/client/e2e/capacity-and-misc.spec.ts
+++ b/client/e2e/capacity-and-misc.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -23,7 +24,7 @@ test.describe('Capacity changes', () => {
     const eventId = (await res.json()).event.id as string;
 
     // User 1 fills the single spot
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.fill('#attendeeName', 'First User');
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
@@ -31,7 +32,7 @@ test.describe('Capacity changes', () => {
     // User 2 ends up on waitlist
     const ctx2 = await browser.newContext();
     const page2 = await ctx2.newPage();
-    await page2.goto(`/events/${eventId}`);
+    await gotoHydrated(page2, `/events/${eventId}`);
     await page2.fill('#attendeeName', 'Second User');
     await page2.click('button[type=submit]:has-text("Submit")');
     await expect(page2.getByText('Your response was saved!')).toBeVisible();
@@ -73,14 +74,14 @@ test.describe('Capacity changes', () => {
     const eventId = (await res.json()).event.id as string;
 
     // Three users all RSVP as going
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.fill('#attendeeName', 'User One');
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
 
     const ctx2 = await browser.newContext();
     const page2 = await ctx2.newPage();
-    await page2.goto(`/events/${eventId}`);
+    await gotoHydrated(page2, `/events/${eventId}`);
     await page2.fill('#attendeeName', 'User Two');
     await page2.click('button[type=submit]:has-text("Submit")');
     await expect(page2.getByText('Your response was saved!')).toBeVisible();
@@ -88,7 +89,7 @@ test.describe('Capacity changes', () => {
 
     const ctx3 = await browser.newContext();
     const page3 = await ctx3.newPage();
-    await page3.goto(`/events/${eventId}`);
+    await gotoHydrated(page3, `/events/${eventId}`);
     await page3.fill('#attendeeName', 'User Three');
     await page3.click('button[type=submit]:has-text("Submit")');
     await expect(page3.getByText('Your response was saved!')).toBeVisible();
@@ -126,7 +127,7 @@ test.describe('Group RSVP attendee list', () => {
     });
     const eventId = (await res.json()).event.id as string;
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // First RSVP as Alice
     await page.fill('#attendeeName', 'Alice');
@@ -166,7 +167,7 @@ test.describe('Past event grouping', () => {
       },
     });
 
-    await page.goto('/events');
+    await gotoHydrated(page, '/events');
     await expect(page.getByText('Past Events')).toBeVisible();
     await expect(page.getByText('Old Time Event')).toBeVisible();
   });
@@ -174,7 +175,7 @@ test.describe('Past event grouping', () => {
 
 test.describe('404 page', () => {
   test('navigating to a non-existent route shows 404 Not Found', async ({ page }) => {
-    await page.goto('/not-a-page');
+    await gotoHydrated(page, '/not-a-page');
     await expect(page.getByText('404')).toBeVisible();
     await expect(page.getByText('Not Found')).toBeVisible();
   });
@@ -196,7 +197,7 @@ test.describe('XSS smoke test', () => {
 
     const xssName = '<script>window.__xss=1</script>Mallory';
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.fill('#attendeeName', xssName);
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();

--- a/client/e2e/helpers.ts
+++ b/client/e2e/helpers.ts
@@ -1,0 +1,32 @@
+import type { Page, Response } from '@playwright/test';
+
+/**
+ * Wait until the client app has hydrated.
+ *
+ * The SSR'd markup is in the DOM before any JavaScript runs, so Playwright's
+ * auto-waiting is happy to click a submit button whose handler is not attached
+ * yet. Every form in this app submits via `on:submit|preventDefault`, so such a
+ * click falls through to a native GET submit: the URL becomes something like
+ * `/admin/login?name=e2eadmin&password=...` and the test times out waiting for a
+ * navigation that never happens.
+ *
+ * The root layout sets `data-hydrated` on <body> from `onMount`, which only runs
+ * once the client app has taken over, so waiting on it closes the race. Load
+ * states are not a substitute — hydration finishes somewhere between
+ * `domcontentloaded` and `load`, and which side of `load` it lands on depends on
+ * how fast the machine is. That is exactly why this only ever failed on CI.
+ */
+export async function waitForHydration(page: Page) {
+  await page.waitForSelector('body[data-hydrated="true"]', { state: 'attached' });
+}
+
+/**
+ * `page.goto` plus a hydration wait, returning the navigation response so callers
+ * can still assert on the status. The error routes hydrate too, so this is safe
+ * for 404 and 500 pages.
+ */
+export async function gotoHydrated(page: Page, url: string): Promise<Response | null> {
+  const response = await page.goto(url);
+  await waitForHydration(page);
+  return response;
+}

--- a/client/e2e/hydration.spec.ts
+++ b/client/e2e/hydration.spec.ts
@@ -1,0 +1,33 @@
+import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
+
+// The rest of the suite depends on the root layout marking <body> as hydrated.
+// If that marker is ever removed, every other spec would go back to racing
+// hydration and failing intermittently on slower machines. These tests make that
+// breakage obvious and immediate instead.
+test.describe('hydration marker', () => {
+  test('is set on the body once the client app takes over', async ({ page }) => {
+    await page.goto('/admin/login');
+    await expect(page.locator('body[data-hydrated="true"]')).toBeAttached();
+  });
+
+  test('is absent before hydration, so waiting on it is meaningful', async ({ page }) => {
+    // 'commit' resolves as soon as the response starts, before scripts run. The
+    // SSR'd form is already present at this point, which is why Playwright will
+    // happily click it — but the marker is not, which is what makes the wait work.
+    await page.goto('/admin/login', { waitUntil: 'commit' });
+    expect(await page.locator('form').count()).toBe(1);
+    expect(await page.evaluate(() => document.body.dataset.hydrated ?? null)).toBeNull();
+  });
+
+  test('a form submits through its JS handler once hydrated', async ({ page }) => {
+    // Guards the actual failure mode: a pre-hydration click falls through to a
+    // native GET submit, landing on /admin/login?name=... instead of /events.
+    await gotoHydrated(page, '/admin/login');
+    await page.fill('#name', 'e2eadmin');
+    await page.fill('#password', 'e2epass');
+    await page.click('button[type=submit]');
+    await page.waitForURL('/events');
+    expect(page.url()).not.toContain('?name=');
+  });
+});

--- a/client/e2e/my-rsvps.spec.ts
+++ b/client/e2e/my-rsvps.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -19,19 +20,19 @@ async function createEvent(request: any) {
 
 test.describe('My RSVPs page', () => {
   test('shows empty state when user has no stored RSVPs', async ({ page }) => {
-    await page.goto('/my/rsvps');
+    await gotoHydrated(page, '/my/rsvps');
     await expect(page.getByText("You haven't RSVP'd to any events")).toBeVisible();
   });
 
   test('shows the event after RSVPing to it', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     await page.fill('#attendeeName', 'My RSVPs User');
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
 
-    await page.goto('/my/rsvps');
+    await gotoHydrated(page, '/my/rsvps');
     await expect(page.getByText('My RSVPs Test Event')).toBeVisible();
     await expect(page.getByText(/Going/i)).toBeVisible();
   });
@@ -40,7 +41,7 @@ test.describe('My RSVPs page', () => {
     const eventId = await createEvent(request);
 
     // First RSVP
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.fill('#attendeeName', 'Alice');
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
@@ -51,7 +52,7 @@ test.describe('My RSVPs page', () => {
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
 
-    await page.goto('/my/rsvps');
+    await gotoHydrated(page, '/my/rsvps');
     // Both attendee names should be visible as per-attendee badges
     await expect(page.getByText(/Alice/)).toBeVisible();
     await expect(page.getByText(/Bob/)).toBeVisible();
@@ -59,7 +60,7 @@ test.describe('My RSVPs page', () => {
 
   test('shows empty state after RSVPed event is deleted', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     await page.fill('#attendeeName', 'Stale RSVP User');
     await page.click('button[type=submit]:has-text("Submit")');
@@ -69,7 +70,7 @@ test.describe('My RSVPs page', () => {
       headers: { Authorization: AUTH },
     });
 
-    await page.goto('/my/rsvps');
+    await gotoHydrated(page, '/my/rsvps');
     await expect(page.getByText("You haven't RSVP'd to any events")).toBeVisible();
   });
 
@@ -78,7 +79,7 @@ test.describe('My RSVPs page', () => {
     request,
   }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     await page.fill('#attendeeName', 'Server-Deleted User');
     await page.click('button[type=submit]:has-text("Submit")');
@@ -97,7 +98,7 @@ test.describe('My RSVPs page', () => {
     });
     expect(delRes.ok()).toBeTruthy();
 
-    await page.goto('/my/rsvps');
+    await gotoHydrated(page, '/my/rsvps');
     await expect(page.getByText("You haven't RSVP'd to any events")).toBeVisible();
   });
 });

--- a/client/e2e/poll-lifecycle.spec.ts
+++ b/client/e2e/poll-lifecycle.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -65,7 +66,7 @@ test.describe('Poll lifecycle', () => {
     });
     expect(closeRes.ok()).toBeTruthy();
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // Vote checkboxes should be gone (poll is closed)
     await expect(page.locator('input[type="checkbox"]')).toHaveCount(0);
@@ -92,7 +93,7 @@ test.describe('Poll lifecycle', () => {
     });
     expect(reopenRes.ok()).toBeTruthy();
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // Vote for Chips
     const chipsItem = page.locator('li').filter({ hasText: 'Chips' });
@@ -125,7 +126,7 @@ test.describe('Poll lifecycle', () => {
     );
 
     // Vote for Chips first
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.locator('li').filter({ hasText: 'Chips' }).locator('input[type="checkbox"]').check();
     await page.getByRole('button', { name: 'Save vote' }).click();
     await expect(page.getByText('Vote saved!')).toBeVisible();
@@ -160,7 +161,7 @@ test.describe('Poll lifecycle', () => {
   test('admin deletes poll: widget disappears from event page', async ({ page, request }) => {
     const { eventId, pollId } = await setupEventWithRsvpAndPoll(request);
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await expect(page.getByText('Favourite Snack')).toBeVisible();
 
     const deleteRes = await request.delete(`${API}/admin/polls/${pollId}`, {

--- a/client/e2e/poll-voting.spec.ts
+++ b/client/e2e/poll-voting.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -42,7 +43,7 @@ test.describe('Poll voting', () => {
       { eventId, rsvpId, token }
     );
 
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     const optionA = page.locator('li').filter({ hasText: 'Script A' });
     const optionB = page.locator('li').filter({ hasText: 'Script B' });

--- a/client/e2e/rsvp-flow.spec.ts
+++ b/client/e2e/rsvp-flow.spec.ts
@@ -1,4 +1,5 @@
 import { expect, test } from '@playwright/test';
+import { gotoHydrated } from './helpers';
 
 const API = 'http://localhost:3000';
 const AUTH = 'Basic e2eadmin:e2epass';
@@ -21,14 +22,14 @@ async function createEvent(request: any) {
 test.describe('RSVP flow', () => {
   test('displays the event page with name and location', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await expect(page.getByText('E2E Test Event')).toBeVisible();
     await expect(page.getByText('Test Venue, Berlin')).toBeVisible();
   });
 
   test('can submit an RSVP and see confirmation', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     await page.fill('#attendeeName', 'Test User');
     await page.click('button[aria-pressed="false"]:has-text("Going")');
@@ -39,7 +40,7 @@ test.describe('RSVP flow', () => {
 
   test('shows going status after submitting', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     await page.fill('#attendeeName', 'Alice');
     await page.click('button[type=submit]:has-text("Submit")');
@@ -50,7 +51,7 @@ test.describe('RSVP flow', () => {
 
   test('attendee appears in the attendee list after RSVP', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     await page.fill('#attendeeName', 'Visible User');
     await page.click('button[type=submit]:has-text("Submit")');
@@ -67,14 +68,14 @@ test.describe('RSVP flow', () => {
     // event id (the load function returns { event: null }) crashes the render
     // with a 500 instead of showing a friendly "No Such Event was found!"
     // message. The page should null-guard event before reading its fields.
-    const response = await page.goto('/events/no-such-event-id');
+    const response = await gotoHydrated(page, '/events/no-such-event-id');
     expect(response?.status()).toBe(500);
     await expect(page.getByText('No Such Event was found!')).not.toBeVisible();
   });
 
   test('can edit an existing RSVP and change status to Maybe', async ({ page, request }) => {
     const eventId = await createEvent(request);
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
 
     // Initial RSVP as Going (default)
     await page.fill('#attendeeName', 'Edit RSVP User');
@@ -110,7 +111,7 @@ test.describe('RSVP flow', () => {
     const eventId = (await res.json()).event.id as string;
 
     // User 1 fills the single available spot
-    await page.goto(`/events/${eventId}`);
+    await gotoHydrated(page, `/events/${eventId}`);
     await page.fill('#attendeeName', 'User One');
     await page.click('button[type=submit]:has-text("Submit")');
     await expect(page.getByText('Your response was saved!')).toBeVisible();
@@ -118,7 +119,7 @@ test.describe('RSVP flow', () => {
     // User 2 in a fresh browser context (fresh localStorage, different "device")
     const ctx2 = await browser.newContext();
     const page2 = await ctx2.newPage();
-    await page2.goto(`/events/${eventId}`);
+    await gotoHydrated(page2, `/events/${eventId}`);
     await page2.fill('#attendeeName', 'User Two');
     await page2.click('button[type=submit]:has-text("Submit")');
     await expect(page2.getByText('Your response was saved!')).toBeVisible();

--- a/client/src/routes/+layout.svelte
+++ b/client/src/routes/+layout.svelte
@@ -6,10 +6,18 @@
 
   let { children } = $props();
 
-  import { setContext } from 'svelte';
+  import { onMount, setContext } from 'svelte';
 
   let menuOpen = $state(false);
   setContext('setMenuOpen', (isOpen: boolean) => menuOpen = isOpen);
+
+  onMount(() => {
+    // Marks the point where the client app has taken over from the SSR'd markup.
+    // The E2E suite waits on this before interacting: forms here submit via
+    // on:submit|preventDefault, so a click landing before hydration falls through
+    // to a native GET submit instead of the handler. See e2e/helpers.ts.
+    document.body.dataset.hydrated = 'true';
+  });
 </script>
 
 <svelte:head>


### PR DESCRIPTION
admin-login intermittently failed on CI with a timeout waiting for
/events, having navigated to /admin/login?name=e2eadmin&password=...
instead. Every form in the app submits via on:submit|preventDefault, and
the SSR'd markup is in the DOM before any JS runs, so Playwright's
auto-waiting would click submit before the handler was attached and the
browser fell through to a native GET submit.

Load states are not a fix: hydration completes somewhere between
domcontentloaded and load depending on machine speed, which is why this
only ever failed on the slower CI runner.

The root layout now marks <body data-hydrated> from onMount, and a
gotoHydrated helper waits for it. All 45 navigations across the suite go
through the helper. hydration.spec.ts guards the marker itself so it
cannot be dropped without an obvious failure.
